### PR TITLE
Allow requestFullscreen() to be called from an orientation change event (closes #34)

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -9,7 +9,7 @@
 
 <hgroup>
  <h1 class="p-name">Fullscreen API</h1>
- <h2 class="no-num no-toc">Living Standard — Last Updated 20 July 2016</h2>
+ <h2 class="no-num no-toc">Living Standard — Last Updated 21 July 2016</h2>
 </hgroup>
 
  <dl>
@@ -195,6 +195,15 @@ steps:
 
 <p><dfn id="fullscreen-is-supported">Fullscreen is supported</dfn> if there is no previously-established user
 preference, security risk, or platform limitation.
+
+<p>An algorithm is <dfn id="allowed-to-request-fullscreen">allowed to request fullscreen</dfn> if one of the following is true:
+
+ <ul>
+  <li><p>The algorithm is <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">triggered by user activation</a>.
+
+  <li><p>The algorithm is
+  <a class="external" data-anolis-spec="screen-orientation" href="https://w3c.github.io/screen-orientation/#dfn-triggered-by-a-user-generated-orientation-change">triggered by a user generated orientation change</a>.
+ </ul>
 <!-- cross-process -->
 
 
@@ -281,10 +290,9 @@ method, when invoked, must run these steps:
    <li><p>The <a href="#fullscreen-element-ready-check">fullscreen element ready check</a> for <var title="">pending</var>
    returns false.
 
-   <li><p>This algorithm is not
-   <a class="external" data-anolis-spec="html" href="https://html.spec.whatwg.org/multipage/browsers.html#allowed-to-show-a-popup">allowed to show a popup</a>.
-
    <li><p><a href="#fullscreen-is-supported" title="Fullscreen is supported">Fullscreen is <em>not</em> supported</a>.
+
+   <li><p>This algorithm is not <a href="#allowed-to-request-fullscreen">allowed to request fullscreen</a>.
   </ul>
 
  <li><p>Return <var>promise</var>, and run the remaining steps
@@ -750,6 +758,7 @@ João Eiras,
 Josh Soref,
 Matt Falkenhagen,
 Mihai Balan,
+Mounir Lamouri,
 Øyvind Stenhaug,
 Pat Ladd,
 Philip Jägenstedt,

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -180,6 +180,15 @@ steps:
 
 <p><dfn>Fullscreen is supported</dfn> if there is no previously-established user
 preference, security risk, or platform limitation.
+
+<p>An algorithm is <dfn>allowed to request fullscreen</dfn> if one of the following is true:
+
+ <ul>
+  <li><p>The algorithm is <span data-anolis-spec=html>triggered by user activation</span>.
+
+  <li><p>The algorithm is
+  <span data-anolis-spec=screen-orientation>triggered by a user generated orientation change</span>.
+ </ul>
 <!-- cross-process -->
 
 
@@ -266,10 +275,9 @@ method, when invoked, must run these steps:
    <li><p>The <span>fullscreen element ready check</span> for <var title>pending</var>
    returns false.
 
-   <li><p>This algorithm is not
-   <span data-anolis-spec=html>allowed to show a popup</span>.
-
    <li><p><span title="Fullscreen is supported">Fullscreen is <em>not</em> supported</span>.
+
+   <li><p>This algorithm is not <span>allowed to request fullscreen</span>.
   </ul>
 
  <li><p>Return <var>promise</var>, and run the remaining steps
@@ -714,6 +722,7 @@ João Eiras,
 Josh Soref,
 Matt Falkenhagen,
 Mihai Balan,
+Mounir Lamouri,
 Øyvind Stenhaug,
 Pat Ladd,
 Philip Jägenstedt,


### PR DESCRIPTION
This is using https://github.com/w3c/screen-orientation/pull/90