### PR TITLE
Update fullscreen spec to be Shadow DOM compliant

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -78,25 +78,27 @@ unset.
 <p>All <{iframe}> <a>elements</a> have an associated <dfn>iframe fullscreen flag</dfn>. Unless
 stated otherwise it is unset.
 
-<p>All <a>documents</a> have an associated <dfn>fullscreen element</dfn>. The
-<a>fullscreen element</a> is the topmost <a>element</a> in the <a>document</a>'s <a>top layer</a>
-whose <a>fullscreen flag</a> is set, if any, and null otherwise.
+<p>All <a>document trees</a> have an associated <dfn>fullscreen element</dfn>. The
+<a>fullscreen element</a> is the topmost <a>element</a> in the <a>document tree</a>'s
+<a>top layer</a> whose <a>fullscreen flag</a> is set, if any, and null otherwise.
 
-<p>To <dfn>fullscreen an <var>element</var></dfn> within a <var>document</var>, set the
-<var>element</var>'s <a>fullscreen flag</a> and <a>add</a> it to <var>document</var>'s
+<p>To <dfn>fullscreen an <var>element</var></dfn> within a <a>document tree</a> whose root is
+<var>document</var>, set the <var>element</var>'s <a>fullscreen flag</a> and <a>add</a> it to
+<var>document</var>'s <a>top layer</a>.
+
+<p>To <dfn>unfullscreen an <var>element</var></dfn> within a <a>document tree</a> whose root is
+<var>document</var>, unset the <var>element</var>'s <a>fullscreen flag</a> and
+<a>iframe fullscreen flag</a> (if any), and <a>remove</a> it from <var>document</var>'s
 <a>top layer</a>.
 
-<p>To <dfn>unfullscreen an <var>element</var></dfn> within a <var>document</var>, unset the
-<var>element</var>'s <a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and
-<a>remove</a> it from <var>document</var>'s <a>top layer</a>.
-
-<p>To <dfn>unfullscreen a <var>document</var></dfn>,
+<p>To <dfn>unfullscreen a document tree</dfn> whose root is <var>document</var>,
 <a lt="unfullscreen an element">unfullscreen</a> all <a>elements</a>, within <var>document</var>'s
 <a>top layer</a>, whose <a>fullscreen flag</a> is set.
 
 <hr>
 
-<p>To <dfn>fully exit fullscreen</dfn> a <a>document</a> <var>document</var>, run these steps:
+<p>To <dfn>fully exit fullscreen</dfn> a <a>document tree</a> whose root is <var>document</var>,
+run these steps:
 
 <ol>
  <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, terminate these steps.
@@ -111,15 +113,15 @@ whose <a>fullscreen flag</a> is set, if any, and null otherwise.
 <p>Whenever the <a>removing steps</a> run with an <var>oldNode</var>, run these steps:
 
 <ol>
- <li><p>Let <var>nodes</var> be <var>oldNode</var>'s <a>inclusive descendants</a> that have their
- <a>fullscreen flag</a> set, in <a>tree order</a>.
+ <li><p>Let <var>nodes</var> be <var>oldNode</var>'s <a>shadow-including inclusive descendants</a>
+ that have their <a>fullscreen flag</a> set, in <a>shadow-including tree order</a>.
 
  <li>
   <p>For each <var>node</var> in <var>nodes</var>, run these substeps:
 
   <ol>
    <li><p>If <var>node</var> is its <a>node document</a>'s <a>fullscreen element</a>,
-   <a>exit fullscreen</a> that <a>document</a>.
+   <a>exit fullscreen</a> that <a>document tree</a>.
 
    <li><p>Otherwise, <a lt="unfullscreen an element">unfullscreen <var>node</var></a> within its
    <a>node document</a>.
@@ -154,13 +156,16 @@ partial interface Element {
 
 partial interface Document {
   [LenientSetter] readonly attribute boolean fullscreenEnabled;
-  [LenientSetter] readonly attribute Element? fullscreenElement;
   [LenientSetter] readonly attribute boolean fullscreen; // historical
 
   Promise&lt;void> exitFullscreen();
 
   attribute EventHandler onfullscreenchange;
   attribute EventHandler onfullscreenerror;
+};
+
+partial interface DocumentOrShadowRoot {
+  [LenientSetter] readonly attribute Element? fullscreenElement;
 };
 </pre>
 
@@ -172,12 +177,17 @@ partial interface Document {
  <dd><p>Returns true if <var>document</var> has the ability to display <a>elements</a> fullscreen
  and <a>fullscreen is supported</a>, or false otherwise.
 
- <dt><code><var>document</var> . {{Document/fullscreenElement}}</code>
- <dd><p>Returns <var>document</var>'s <a>fullscreen element</a>.
-
  <dt><code><var>promise</var> = <var>document</var> . {{Document/exitFullscreen()}}</code>
  <dd><p>Stops <var>document</var>'s <a>fullscreen element</a> from being displayed fullscreen and
  fulfills <var>promise</var> when done.
+
+ <dt><code><var>document</var> . {{DocumentOrShadowRoot/fullscreenElement}}</code>
+ <dd><p>Returns the result of retargeting <var>document</var>'s <a>fullscreen element</a> against
+ <var>document</var>.
+
+ <dt><code><var>shadowroot</var> . {{DocumentOrShadowRoot/fullscreenElement}}</code>
+ <dd><p>Returns the result of retargeting <var>document</var>'s <a>fullscreen element</a> against
+ <var>shadowroot</var> if the result is in the same tree as <var>shadowroot</var>.
 </dl>
 
 <p>A <dfn>fullscreen element ready check</dfn> for an <a>element</a> <var>element</var> returns true
@@ -191,7 +201,7 @@ if all of the following are true, and false otherwise:
  <a href=https://www.w3.org/Math/draft-spec/chapter2.html#interf.toplevel>MathML <code>math</code></a>
  element. [[!SVG]] [[!MATHML]]
 
- <li><p><var>element</var> is <a>in a document</a>.
+ <li><p><var>element</var> is <a>in a document tree</a>.
 
  <li><p><var>element</var>'s <a>node document</a> is <a>allowed to use</a> the feature indicated by
  attribute name <code>allowfullscreen</code>.
@@ -289,14 +299,17 @@ these steps:
 return true if the <a>context object</a> is <a>allowed to use</a> the feature indicated by attribute
 name <code>allowfullscreen</code> and <a>fullscreen is supported</a>, and false otherwise.
 
-<p>The <dfn attribute for=Document><code>fullscreenElement</code></dfn> attribute's getter must
-return <a>context object</a>'s <a>fullscreen element</a>.
-
 <p>The <dfn attribute for=Document><code>fullscreen</code></dfn> attribute's getter must return
 false if <a>context object</a>'s <a>fullscreen element</a> is null, and true otherwise.
 
 <p class=note>Use
-<a attribute for=Document lt=fullscreenElement><code>document.fullscreenElement</code></a> instead.
+<a attribute for=DocumentOrShadowRoot lt=fullscreenElement><code>document.fullscreenElement</code></a>
+instead.
+
+<p>The <dfn attribute for=DocumentOrShadowRoot><code>fullscreenElement</code></dfn> attribute's
+getter must return the result of <a>retargeting</a> <a>context object</a>'s
+<a>shadow-including root</a>'s <a>fullscreen element</a> against <a>context object</a> if the
+result and the <a>context object</a> are in the same tree, otherwise return null.
 
 <p>To <dfn>collect documents to unfullscreen</dfn> given <var>doc</var>, run these steps:
 
@@ -314,7 +327,7 @@ false if <a>context object</a>'s <a>fullscreen element</a> is null, and true oth
  <li><p>Return <var>docs</var>.
 </ol>
 
-<p>To <dfn>exit fullscreen</dfn> a <a>document</a> <var>doc</var>, run these steps:
+<p>To <dfn>exit fullscreen</dfn> a <a>document tree</a> <var>doc</var>, run these steps:
 
 <ol>
  <li><p>Let <var>promise</var> be a new promise.
@@ -366,7 +379,7 @@ false if <a>context object</a>'s <a>fullscreen element</a> is null, and true oth
    <!-- cross-process -->
 
    <li><p>For each <var>descendantDoc</var> in <var>descendantDocs</var>, in order,
-   <a lt="unfullscreen a document">unfullscreen <var>descendantDoc</var></a>.
+   <a lt="unfullscreen a document tree">unfullscreen <var>descendantDoc</var></a>.
    <!-- cross-process -->
 
    <li><p>For each <var>exitDoc</var> in <var>exitDocs</var>, in order,
@@ -467,8 +480,8 @@ following characteristics:
  is the viewport, and the initial containing block otherwise.
 
  <li><p>If it is an element, it and its <a><code>::backdrop</code></a> pseudo-element are not
- rendered if its <a>inclusive ancestor</a> has the <code>display</code> property set to
- <code>none</code>.
+ rendered if its <a>shadow-including inclusive ancestor</a> has the <code>display</code> property
+ set to <code>none</code>.
 
  <li><p>If its specified <code>display</code> property is <code>contents</code>, it computes to
  <code>block</code>.
@@ -512,7 +525,8 @@ properties apply to this pseudo-element either.
 <p>The <dfn id=css-pc-fullscreen><code>:fullscreen</code></dfn> pseudo-class must match any
 <a>element</a> that has its <a>fullscreen flag</a> set.
 
-<p class="note no-backref">This makes it different from the {{Document/fullscreenElement}} API,
+<p class="note no-backref">This makes it different from the
+{{DocumentOrShadowRoot/fullscreenElement}} API,
 which returns a <a>document</a>'s <a>fullscreen element</a>.
 
 


### PR DESCRIPTION
Spec discussion at https://github.com/w3c/webcomponents/issues/180.

The rough consensus was:
https://github.com/w3c/webcomponents/issues/180#issuecomment-224244250

This resolves #42