### PR TITLE
Check the fullscreen element in the animation frame task for exit

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -314,8 +314,8 @@ attribute's getter must run these steps:
 <ol>
  <li><p>Let <var>promise</var> be a new promise.
 
- <li><p>If <var>doc</var>'s <a>fullscreen element</a> is null, reject <var>promise</var> with a
- <code>TypeError</code> exception, and return <var>promise</var>.
+ <li><p>If <var>doc</var>'s <a>fullscreen element</a> is null, fulfill <var>promise</var> with
+ undefined, and return <var>promise</var>.
 
  <li><p>Let <var>resize</var> be false.
 
@@ -339,6 +339,9 @@ attribute's getter must run these steps:
   <p>As part of the next <a>animation frame task</a>, run these substeps:
 
   <ol>
+
+   <li><p>If <var>doc</var>'s <a>fullscreen element</a> is null, fulfill <var>promise</var> with
+   undefined, and terminate these steps.
 
    <li><p>Let <var>exitDocs</var> be the result of
    <a lt="collect documents to unfullscreen">collecting documents to unfullscreen</a> given


### PR DESCRIPTION
The change to fulfill instead of reject is a drive-by for consistency.

The problem in the animation frame task was that if there are two
exitFullscreen() calls for the same document in the same animation frame
task, and an ancestor document has more than one fullscreen element in
its top layer, then the first task could pop one of them, and the second
another, potentially exiting out of fullscreen entirely.

With this change, exitFullscreen() is still not idempotent as doc's top
layer may be emptied where just one call would not, but at least it
stops when obviously silly things are happening.