### PR TITLE
Reject exitFullscreen() in inactive documents

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -314,11 +314,9 @@ attribute's getter must run these steps:
 <ol>
  <li><p>Let <var>promise</var> be a new promise.
 
- <li><p>If <var>doc</var> is not <a>fully active</a>, then reject <var>promise</var> with a
- <code>TypeError</code> exception and return <var>promise</var>.
-
- <li><p>If <var>doc</var>'s <a>fullscreen element</a> is null, then reject <var>promise</var> with a
- <code>TypeError</code> exception and return <var>promise</var>.
+ <li><p>If <var>doc</var> is not <a>fully active</a> or <var>doc</var>'s <a>fullscreen element</a>
+ is null, then reject <var>promise</var> with a <code>TypeError</code> exception and return
+ <var>promise</var>.
 
  <li><p>Let <var>resize</var> be false.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -314,8 +314,11 @@ attribute's getter must run these steps:
 <ol>
  <li><p>Let <var>promise</var> be a new promise.
 
- <li><p>If <var>doc</var>'s <a>fullscreen element</a> is null, reject <var>promise</var> with a
- <code>TypeError</code> exception, and return <var>promise</var>.
+ <li><p>If <var>doc</var> is not <a>fully active</a>, then reject <var>promise</var> with a
+ <code>TypeError</code> exception and return <var>promise</var>.
+
+ <li><p>If <var>doc</var>'s <a>fullscreen element</a> is null, then reject <var>promise</var> with a
+ <code>TypeError</code> exception and return <var>promise</var>.
 
  <li><p>Let <var>resize</var> be false.
 

--- a/fullscreen.html
+++ b/fullscreen.html
@@ -312,7 +312,9 @@ false if <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-obje
     <li>
      <p>Let <var>promise</var> be a new promise. </p>
     <li>
-     <p>If <var>doc</var>’s <a data-link-type="dfn" href="#fullscreen-element">fullscreen element</a> is null, reject <var>promise</var> with a <code>TypeError</code> exception, and return <var>promise</var>. </p>
+     <p>If <var>doc</var> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active">fully active</a>, then reject <var>promise</var> with a <code>TypeError</code> exception and return <var>promise</var>. </p>
+    <li>
+     <p>If <var>doc</var>’s <a data-link-type="dfn" href="#fullscreen-element">fullscreen element</a> is null, then reject <var>promise</var> with a <code>TypeError</code> exception and return <var>promise</var>. </p>
     <li>
      <p>Let <var>resize</var> be false. </p>
     <li>

--- a/fullscreen.html
+++ b/fullscreen.html
@@ -312,9 +312,7 @@ false if <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-obje
     <li>
      <p>Let <var>promise</var> be a new promise. </p>
     <li>
-     <p>If <var>doc</var> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active">fully active</a>, then reject <var>promise</var> with a <code>TypeError</code> exception and return <var>promise</var>. </p>
-    <li>
-     <p>If <var>doc</var>’s <a data-link-type="dfn" href="#fullscreen-element">fullscreen element</a> is null, then reject <var>promise</var> with a <code>TypeError</code> exception and return <var>promise</var>. </p>
+     <p>If <var>doc</var> is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active">fully active</a> or <var>doc</var>’s <a data-link-type="dfn" href="#fullscreen-element">fullscreen element</a> is null, then reject <var>promise</var> with a <code>TypeError</code> exception and return <var>promise</var>. </p>
     <li>
      <p>Let <var>resize</var> be false. </p>
     <li>


### PR DESCRIPTION
If the document becomes inactive after the request, then there will not
be another animation frame task, in which case the promise will be left
hanging instead.

Fixes #67.