### PR TITLE
Fix Bikeshed error about SVG reference

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -36,6 +36,9 @@ urlPrefix: https://w3c.github.io/screen-orientation/#dfn-
 {
     "CSS": {
         "aliasOf": "CSS2"
+    },
+    "SVG": {
+        "aliasOf": "SVG11"
     }
 }
 </pre>


### PR DESCRIPTION
Bikeshed complained that "[SVG] is replaced by [SVG11]."

Keep using [SVG] with no number, like for [CSS].


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fullscreen.spec.whatwg.org/branch-snapshots/svg-ref/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fullscreen/40c8947...c81af9d.html)