### PR TITLE
Editorial: update variable name in removing steps

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -97,14 +97,15 @@ its <a>node document</a>'s <a>top layer</a>.
  <li><p><a>Exit fullscreen</a> <var>document</var>.
 </ol>
 
-<p>Whenever the <a>removing steps</a> run with an <var>oldNode</var>, run these steps:
+<p>Whenever the <a>removing steps</a> run with a <var>removedNode</var>, run these steps:
 
 <ol>
- <li><p>Let <var>nodes</var> be <var>oldNode</var>'s <a>shadow-including inclusive descendants</a>
- that have their <a>fullscreen flag</a> set, in <a>shadow-including tree order</a>.
+ <li><p>Let <var>nodes</var> be <var>removedNode</var>'s
+ <a>shadow-including inclusive descendants</a> that have their <a>fullscreen flag</a> set, in
+ <a>shadow-including tree order</a>.
 
  <li>
-  <p><a>For each</a> <var>node</var> in <var>nodes</var>, run these substeps:
+  <p><a>For each</a> <var>node</var> in <var>nodes</var>:
 
   <ol>
    <li><p>If <var>node</var> is its <a>node document</a>'s <a>fullscreen element</a>,


### PR DESCRIPTION
https://dom.spec.whatwg.org/#concept-node-remove-ext uses removedNode
and an optional oldParent, which isn't used by Fullscreen.

Drive-by: drop unnecessary "run these substeps"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fullscreen.spec.whatwg.org/branch-snapshots/removing-steps/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fullscreen/50efe97...625d044.html)