### PR TITLE
Clarify what "collect documents to unfullscreen" returns

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -320,6 +320,8 @@ could be an open <{dialog}> element.
   <ol>
    <li><p>Let <var>lastDoc</var> be <var>docs</var>'s last <a for=/>document</a>.
 
+   <li><p>Assert: <var>lastDoc</var>'s <a>fullscreen element</a> is not null.
+
    <li><p>If <var>lastDoc</var> is not a <a>simple fullscreen document</a>, <a>break</a>.
 
    <li><p>Let <var>container</var> be <var>lastDoc</var>'s <a>browsing context container</a>, if
@@ -331,6 +333,11 @@ could be an open <{dialog}> element.
   </ol>
 
  <li><p>Return <var>docs</var>.
+
+ <p class=note>This is the set of documents for which the <a>fullscreen element</a> will be
+ <a lt="unfullscreen an element">unfullscreened</a>, but the last document in <var>docs</var> might
+ have more than one <a>element</a> in its <a>top layer</a> with the <a>fullscreen flag</a> set,
+ in which case that document will still remain in fullscreen.
 </ol>
 
 <p>To <dfn>exit fullscreen</dfn> a <a for=/>document</a> <var>doc</var>, run these steps:
@@ -365,6 +372,8 @@ could be an open <{dialog}> element.
   <p>As part of the next <a>animation frame task</a>, run these substeps:
 
   <ol>
+   <li><p>If <var>doc</var>'s <a>fullscreen element</a> is null, then resolve <var>promise</var>
+   with undefined and terminate these steps.
 
    <li><p>Let <var>exitDocs</var> be the result of
    <a lt="collect documents to unfullscreen">collecting documents to unfullscreen</a> given


### PR DESCRIPTION
Given that there is an "unfullscreen a document" operation, this
algorithm can easily be assumed to be the set of documents for which
that should be called, i.e., that all of the documents returned will
exit fully.

At the beginning of the animation frame task there's no guarantee that
doc still has a fullscreen element, but later in "unfullscreen exitDoc's
fullscreen element" it is assumed to have one. Fix this with an early
return.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fullscreen.spec.whatwg.org/branch-snapshots/collect-documents-to-unfullscreen/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fullscreen/c8164af...ae151d8.html)