### PR TITLE
Editorial: use Infra's break to clarify requestFullscreen() iteration

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -243,15 +243,13 @@ these steps:
    <li><p>Let <var>eventDocs</var> be a new <a>ordered set</a>.
 
    <li>
-    <p><a>For each</a> <var>element</var> in <var>fullscreenElements</var>, run these
-    subsubsteps:
+    <p><a>For each</a> <var>element</var> in <var>fullscreenElements</var>:
 
     <ol>
      <li><p>Let <var>doc</var> be <var>element</var>'s <a>node document</a>.
 
      <li>
-      <p>If <var>element</var> is <var>doc</var>'s <a>fullscreen element</a>, terminate these
-      subsubsteps.
+      <p>If <var>element</var> is <var>doc</var>'s <a>fullscreen element</a>, <a>continue</a>.
 
       <p class=note>No need to notify observers when nothing has changed.
 


### PR DESCRIPTION
The implementation in Blink uses continue here, which would matter if
one of the ancestor documents had a fullscreen element other than the
iframe containing the document now requesting fullscreen.

Perhaps this should be continue, but that would be a separate change.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fullscreen.spec.whatwg.org/branch-snapshots/infra-break/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fullscreen/0a4787a...15e285f.html)