### PR TITLE
Add [Unscopable] to Document.prototype.fullscreen

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -144,7 +144,7 @@ partial interface Element {
 
 partial interface Document {
   [LenientSetter] readonly attribute boolean fullscreenEnabled;
-  [LenientSetter] readonly attribute boolean fullscreen; // historical
+  [LenientSetter, Unscopable] readonly attribute boolean fullscreen; // historical
 
   Promise&lt;void> exitFullscreen();
 


### PR DESCRIPTION
This appears to be needed per
https://bugzilla.mozilla.org/show_bug.cgi?id=1364025.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fullscreen.spec.whatwg.org/branch-snapshots/annevk/unscopable/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fullscreen/946d3ec...5e8528d.html)