### PR TITLE
Disallow dialog.requestFullscreen()

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -246,6 +246,8 @@ these steps:
    <a href=https://www.w3.org/Math/draft-spec/chapter2.html#interf.toplevel>MathML <code>math</code></a>
    element. [[!SVG]] [[!MATHML]]
 
+   <li><p><var>pending</var> is not a <{dialog}> element.
+
    <li><p>The <a>fullscreen element ready check</a> for <var>pending</var> returns true.
 
    <li><p><a>Fullscreen is supported</a>.


### PR DESCRIPTION
This way, interactions between the algorithms for fullscreen and
dialog are simplified. Example concern:
https://github.com/whatwg/fullscreen/pull/102#issuecomment-332039536

This also makes it easier to reinstate hierarchy restrictions:
https://github.com/whatwg/fullscreen/pull/91

Tests: https://chromium-review.googlesource.com/c/chromium/src/+/684435


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://fullscreen.spec.whatwg.org/branch-snapshots/disallow-dialog/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/fullscreen/10649f2...70e0801.html)