### PR TITLE
Editorial: remove a stray/double "tree order" in note

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -440,7 +440,6 @@ could be an open <{dialog}> element.
 
  <p class=note>The order in which documents are <a lt="unfullscreen a document">unfullscreened</a>
  is not observable, because the <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
- <a>tree order</a>.
 
  <li><p>Resolve <var>promise</var> with undefined.
 </ol>


### PR DESCRIPTION
Mistake in https://github.com/whatwg/fullscreen/pull/94.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/117.html" title="Last updated on Jan 29, 2018, 8:40 AM GMT (a8564e5)">Preview</a> | <a href="https://whatpr.org/fullscreen/117/eac5263...a8564e5.html" title="Last updated on Jan 29, 2018, 8:40 AM GMT (a8564e5)">Diff</a>