### PR TITLE
Editorial: fix grammar in notes about run the fullscreen steps

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -300,7 +300,7 @@ these steps:
   </ol>
 
   <p class=note>The order in which elements are <a lt="fullscreen an element">fullscreened</a>
-  is not observable, because the <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
+  is not observable, because <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
 
  <li><p>Resolve <var>promise</var> with undefined.
 </ol>
@@ -439,7 +439,7 @@ could be an open <{dialog}> element.
   </ol>
 
  <p class=note>The order in which documents are <a lt="unfullscreen a document">unfullscreened</a>
- is not observable, because the <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
+ is not observable, because <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
 
  <li><p>Resolve <var>promise</var> with undefined.
 </ol>


### PR DESCRIPTION
Oversight in https://github.com/whatwg/fullscreen/pull/94.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/118.html" title="Last updated on Jan 29, 2018, 8:51 AM GMT (0d5c71b)">Preview</a> | <a href="https://whatpr.org/fullscreen/118/2d7f7f0...0d5c71b.html" title="Last updated on Jan 29, 2018, 8:51 AM GMT (0d5c71b)">Diff</a>