### PR TITLE
Remove from top layer synchronously for not connected elements

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -92,6 +92,8 @@ its <a>node document</a>'s <a>top layer</a>.
 these steps:
 
 <ol>
+ <li><p>Let <var>document</var> be <var>removedNode</var>'s <a>node document</a>.
+
  <li><p>Let <var>nodes</var> be <var>removedNode</var>'s
  <a>shadow-including inclusive descendants</a> that have their <a>fullscreen flag</a> set, in
  <a>shadow-including tree order</a>.
@@ -100,11 +102,18 @@ these steps:
   <p><a>For each</a> <var>node</var> in <var>nodes</var>:
 
   <ol>
-   <li><p>If <var>node</var> is its <a>node document</a>'s <a>fullscreen element</a>,
-   <a>exit fullscreen</a> that <a for=/>document</a>.
+   <li><p>If <var>node</var> is <var>document</var>'s <a>fullscreen element</a>,
+   <a>exit fullscreen</a> <var>document</var>.
 
-   <li><p>Otherwise, <a lt="unfullscreen an element">unfullscreen <var>node</var></a> within its
-   <a>node document</a>.
+   <li><p>Otherwise, <a lt="unfullscreen an element">unfullscreen <var>node</var></a>.
+
+   <li>
+    <p>If <var>document</var>'s <a>top layer</a> <a for=set>contains</a> <var>node</var>,
+    <a for=set>remove</a> <var>node</var> from <var>document</var>'s <var>top layer</var>.
+
+    <p class=note>Other specifications can add and remove elements from <a>top layer</a>, so
+    <var>node</var> might not be <var>document</var>'s <a>fullscreen element</a>. For example,
+    <var>node</var> could be an open <{dialog}> element.
   </ol>
 </ol>
 
@@ -398,6 +407,13 @@ could be an open <{dialog}> element.
  <a>simple fullscreen document</a>, then set <var>doc</var> to <var>topLevelDoc</var> and
  <var>resize</var> to true.
 
+ <li><p>If <var>doc</var>'s <a>fullscreen element</a> is not <a>connected</a>:
+  <ol>
+   <li><p><a for=set>Append</a> (<code>fullscreenchange</code>, <var>doc</var>'s
+   <a>fullscreen element</a>) to <var>doc</var>'s
+   <a>list of pending fullscreen events</a>.
+  </ol>
+
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
  <li><p>If <var>resize</var> is true, resize <var>doc</var>'s viewport to its "normal" dimensions.
@@ -676,6 +692,7 @@ delivered with the <a>document</a> through which it is nested.
 Andy Earnshaw,
 Chris Pearce,
 Darin Fisher,
+Dave Tapuska,
 <i>fantasai</i>,
 Giuseppe Pascale,
 Glenn Maynard,


### PR DESCRIPTION
If the fullscreen element is not connected anymore dispatch
event and unfullscreen the element right away.

This allows an element that is being removed to see that it isn't the
fullscreen element synchronously.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen-1/128.html" title="Last updated on Aug 22, 2018, 8:40 PM GMT (349d042)">Preview</a> | <a href="https://whatpr.org/fullscreen/128/05c072b...349d042.html" title="Last updated on Aug 22, 2018, 8:40 PM GMT (349d042)">Diff</a>