### PR TITLE
Add FullscreenOptions dictionary to requestFullscreen

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -273,15 +273,34 @@ when invoked, must run these steps:
 
  <li>
   <p>If <var>error</var> is false: Resize <var>pendingDoc</var>'s
-  <a>top-level browsing context</a>'s <a>active document</a>'s viewport's dimensions to match the
-  dimensions of the available screen of the output device, optionally taking into account
-  <var>options</var>'s <code>navigationUI</code> member. Optionally display a message how the end
-  user can revert this.
+  <a>top-level browsing context</a>'s <a>active document</a>'s viewport's dimensions, optionally
+  taking into account <var>options</var>'s <code>navigationUI</code> member:
   <!-- cross-process -->
 
-  <p class=note>The <code>navigationUI</code> member is a hint to the user agent about what the
-  author thinks will lead to the best user experience. The member might be ignored altogether, for
-  example based on user preferences.
+  <table>
+    <thead>
+      <tr>
+      <th>value</th>
+      <th>viewport dimensions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>"<code>hide</code>"</td>
+        <td>full dimensions of the screen of the output device</td>
+      </tr>
+      <tr>
+        <td>"<code>show</code>"</td>
+        <td>dimensions of the screen of the output device clamped to allow the user agent to show page navigation controls</td>
+      </tr>
+      <tr>
+        <td>"<code>auto</code>"</td>
+        <td>user-agent defined, but matching one of the above</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>Optionally display a message how the end user can revert this.
 
  <li>
   <p>If any of the following conditions are false, then set <var>error</var> to true:

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -199,8 +199,15 @@ partial interface DocumentOrShadowRoot {
      interface, which is implemented by Document and HTMLElement, not Element. -->
 
 <dl class=domintro>
- <dt><code><var>promise</var> = <var>element</var> . {{Element/requestFullscreen(<var>options</var>)}}</code>
- <dd><p>Displays <var>element</var> fullscreen with <var>options</var> and resolves <var>promise</var> when done.
+ <dt><code><var>promise</var> = <var>element</var> . <a method for=Element lt=requestFullscreen()>requestFullscreen([<var>options</var>])</a></code>
+ <dd>
+  Displays <var>element</var> fullscreen and resolves <var>promise</var> when done.
+
+  When supplied, <var>options</var>'s <code>navigationUI</code> member indicates whether showing
+  navigation UI while in fullscreen is preferred or not. If set to "<code>show</code>", navigation
+  simplicity is preferred over screen space, and if set to "<code>hide</code>", more screen space
+  is preferred. User agents are always free to honor user preference over the application. The
+  default value "<code>auto</code>" indicates no application preference.
 
  <dt><code><var>document</var> . {{Document/fullscreenEnabled}}</code>
  <dd><p>Returns true if <var>document</var> has the ability to display <a>elements</a> fullscreen

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -235,23 +235,8 @@ if all of the following are true, and false otherwise:
  <!-- cross-process, recursive -->
 </ul>
 
-<p>The {{FullscreenOptions}} dictionary can be used to help customize the User Agent UI:
-<ul>
-<li>
- <dl>
-  <dt>{{navigationUI}}</dt>
-  <dd>Some User Agents may have a navigator bar that can be hidden providing more screen space at the
-  cost of increased user actions to perform navigation actions. This attribute if set to
-  <code>hide</code> tells the user agent the application prefers more screen space over requiring
-  the user to perform more actions. If set to <code>show</code> it tells the user agent to prefer
-  user action simplicity over screen space.</dd> If set to <code>auto</code> the user agent is
-  free to decide.
- </dl>
-</li>
-</ul>
-
-<p>The <dfn method for=Element><code>requestFullscreen(options)</code></dfn> method, when invoked, must run
-these steps:
+<p>The <dfn method for=Element><code>requestFullscreen(<var>options</var>)</code></dfn> method,
+when invoked, must run these steps:
 
 <ol>
  <li><p>Let <var>pending</var> be the <a>context object</a>.
@@ -286,11 +271,17 @@ these steps:
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
- <li><p>If <var>error</var> is false: Resize <var>pendingDoc</var>'s
- <a>top-level browsing context</a>'s <a>active document</a>'s viewport's dimensions to match the
- dimensions of the screen of the output device. Optionally display a message how the end user can
- revert this.
- <!-- cross-process -->
+ <li>
+  <p>If <var>error</var> is false: Resize <var>pendingDoc</var>'s
+  <a>top-level browsing context</a>'s <a>active document</a>'s viewport's dimensions to match the
+  dimensions of the available screen of the output device, optionally taking into account
+  <var>options</var>'s <code>navigationUI</code> member. Optionally display a message how the end
+  user can revert this.
+  <!-- cross-process -->
+
+  <p class=note>The <code>navigationUI</code> member is a hint to the user agent about what the
+  author thinks will lead to the best user experience. The member might be ignored altogether, for
+  example based on user preferences.
 
  <li>
   <p>If any of the following conditions are false, then set <var>error</var> to true:

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -164,8 +164,18 @@ steps:
 <h2 id=api>API</h2>
 
 <pre class=idl>
+enum <dfn>FullscreenNavigationUI</dfn> {
+  "auto",
+  "show",
+  "hide"
+};
+
+dictionary <dfn>FullscreenOptions</dfn> {
+  FullscreenNavigationUI navigationUI = "auto";
+};
+
 partial interface Element {
-  Promise&lt;void> requestFullscreen();
+  Promise&lt;void> requestFullscreen(optional FullscreenOptions options);
 
   attribute EventHandler onfullscreenchange;
   attribute EventHandler onfullscreenerror;
@@ -189,8 +199,8 @@ partial interface DocumentOrShadowRoot {
      interface, which is implemented by Document and HTMLElement, not Element. -->
 
 <dl class=domintro>
- <dt><code><var>promise</var> = <var>element</var> . {{Element/requestFullscreen()}}</code>
- <dd><p>Displays <var>element</var> fullscreen and resolves <var>promise</var> when done.
+ <dt><code><var>promise</var> = <var>element</var> . {{Element/requestFullscreen(<var>options</var>)}}</code>
+ <dd><p>Displays <var>element</var> fullscreen with <var>options</var> and resolves <var>promise</var> when done.
 
  <dt><code><var>document</var> . {{Document/fullscreenEnabled}}</code>
  <dd><p>Returns true if <var>document</var> has the ability to display <a>elements</a> fullscreen
@@ -218,7 +228,22 @@ if all of the following are true, and false otherwise:
  <!-- cross-process, recursive -->
 </ul>
 
-<p>The <dfn method for=Element><code>requestFullscreen()</code></dfn> method, when invoked, must run
+<p>The {{FullscreenOptions}} dictionary can be used to help customize the User Agent UI:
+<ul>
+<li>
+ <dl>
+  <dt>{{navigationUI}}</dt>
+  <dd>Some User Agents may have a navigator bar that can be hidden providing more screen space at the
+  cost of increased user actions to perform navigation actions. This attribute if set to
+  <code>hide</code> tells the user agent the application prefers more screen space over requiring
+  the user to perform more actions. If set to <code>show</code> it tells the user agent to prefer
+  user action simplicity over screen space.</dd> If set to <code>auto</code> the user agent is
+  free to decide.
+ </dl>
+</li>
+</ul>
+
+<p>The <dfn method for=Element><code>requestFullscreen(options)</code></dfn> method, when invoked, must run
 these steps:
 
 <ol>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -206,7 +206,7 @@ partial interface DocumentOrShadowRoot {
   When supplied, <var>options</var>'s <code>navigationUI</code> member indicates whether showing
   navigation UI while in fullscreen is preferred or not. If set to "<code>show</code>", navigation
   simplicity is preferred over screen space, and if set to "<code>hide</code>", more screen space
-  is preferred. User agents are always free to honor user preference over the application. The
+  is preferred. User agents are always free to honor user preference over the application's. The
   default value "<code>auto</code>" indicates no application preference.
 
  <dt><code><var>document</var> . {{Document/fullscreenEnabled}}</code>


### PR DESCRIPTION
Add an attribute of the FullscreenOptions dictionary that hints
at whether a navigation bar is preferred or not.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen-1/129.html" title="Last updated on Sep 7, 2018, 7:12 PM GMT (af61df4)">Preview</a> | <a href="https://whatpr.org/fullscreen/129/06c6e07...af61df4.html" title="Last updated on Sep 7, 2018, 7:12 PM GMT (af61df4)">Diff</a>