### PR TITLE
Fix logical error of filling fullscreenElements (3.12)

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -327,7 +327,7 @@ when invoked, must run these steps:
  <li><p>Let <var>fullscreenElements</var> be an <a>ordered set</a> initially consisting of
  <var>pending</var>.
 
- <li><p><a>While</a> the first element in <var>fullscreenElements</var> is in a
+ <li><p><a>While</a> the last element in <var>fullscreenElements</var> is in a
  <a>nested browsing context</a>: <a for=set>append</a> its <a>browsing context container</a> to
  <var>fullscreenElements</var>.
  <!-- cross-process -->
@@ -733,6 +733,7 @@ delivered with the <a>document</a> through which it is nested.
 
 <p>Thanks to
 Andy Earnshaw,
+Changwan Hong,
 Chris Pearce,
 Darin Fisher,
 Dave Tapuska,


### PR DESCRIPTION
Closes: #144


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/145.html" title="Last updated on Feb 22, 2019, 3:02 AM UTC (23899b4)">Preview</a> | <a href="https://whatpr.org/fullscreen/145/7ecd709...23899b4.html" title="Last updated on Feb 22, 2019, 3:02 AM UTC (23899b4)">Diff</a>