### PR TITLE
Consume user activation in `element.requestFullscreen()`

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -266,6 +266,9 @@ are:
    algorithm is <a>triggered by a user generated orientation change</a>.
   </ul>
 
+ <li><p>If <var>error</var> is false, then <a>consume user activation</a> given
+ <var>pendingDoc</var>'s <a>relevant global object</a>.
+
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
  <li>


### PR DESCRIPTION
Depends on https://github.com/whatwg/html/pull/3851.

Fixes https://github.com/whatwg/fullscreen/issues/152.

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium: https://github.com/whatwg/fullscreen/pull/153#issuecomment-496521939
   * Gecko: https://github.com/whatwg/fullscreen/pull/153#issuecomment-1298746998
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/36969
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1804635
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=247920
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/22303

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/153.html" title="Last updated on May 3, 2023, 7:23 AM UTC (e1ab822)">Preview</a> | <a href="https://whatpr.org/fullscreen/153/a69e295...e1ab822.html" title="Last updated on May 3, 2023, 7:23 AM UTC (e1ab822)">Diff</a>