### PR TITLE
Add empty dictionary default value for requestFullscreen

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -176,7 +176,7 @@ dictionary <dfn>FullscreenOptions</dfn> {
 };
 
 partial interface Element {
-  Promise&lt;void> requestFullscreen(optional FullscreenOptions options);
+  Promise&lt;void> requestFullscreen(optional FullscreenOptions options = {});
 
   attribute EventHandler onfullscreenchange;
   attribute EventHandler onfullscreenerror;


### PR DESCRIPTION
Closes https://github.com/whatwg/fullscreen/pull/157.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/158.html" title="Last updated on Sep 25, 2019, 9:28 PM UTC (570fe8f)">Preview</a> | <a href="https://whatpr.org/fullscreen/158/2a9e7a5...570fe8f.html" title="Last updated on Sep 25, 2019, 9:28 PM UTC (570fe8f)">Diff</a>