### PR TITLE
Meta: remove <dfn> markup that has no effect on output

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -165,13 +165,13 @@ steps:
 <h2 id=api>API</h2>
 
 <pre class=idl>
-enum <dfn>FullscreenNavigationUI</dfn> {
+enum FullscreenNavigationUI {
   "auto",
   "show",
   "hide"
 };
 
-dictionary <dfn>FullscreenOptions</dfn> {
+dictionary FullscreenOptions {
   FullscreenNavigationUI navigationUI = "auto";
 };
 


### PR DESCRIPTION
The output fullscreen.html is exactly the same before and after this
change.

Was part of https://github.com/whatwg/fullscreen/pull/157.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/159.html" title="Last updated on Sep 26, 2019, 9:24 AM UTC (456da35)">Preview</a> | <a href="https://whatpr.org/fullscreen/159/20ea24b...456da35.html" title="Last updated on Sep 26, 2019, 9:24 AM UTC (456da35)">Diff</a>