### PR TITLE
Editorial: use "transient activation" instead of obsolete concept

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -126,15 +126,6 @@ these steps:
 <p><dfn>Fullscreen is supported</dfn> if there is no previously-established user preference,
 security risk, or platform limitation.
 
-<p>An algorithm is <dfn>allowed to request fullscreen</dfn> if one of the following is true:
-
- <ul>
-  <li><p>The algorithm is <a>triggered by user activation</a>.
-
-  <li><p>The algorithm is <a>triggered by a user generated orientation change</a>.
- </ul>
-<!-- cross-process -->
-
 <hr>
 
 <p>To <dfn>run the fullscreen steps</dfn> for a <a>document</a> <var>document</var>, run these
@@ -267,7 +258,8 @@ when invoked, must run these steps:
 
    <li><p><a>Fullscreen is supported</a>.
 
-   <li><p>This algorithm is <a>allowed to request fullscreen</a>.
+   <li><p><var>pending</var>'s <a>relevant global object</a> has <a>transient activation</a> or the
+   algorithm is <a>triggered by a user generated orientation change</a>.
   </ul>
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.


### PR DESCRIPTION
Fixes https://github.com/whatwg/fullscreen/issues/160.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/163.html" title="Last updated on Jan 29, 2020, 11:43 AM UTC (ac928e1)">Preview</a> | <a href="https://whatpr.org/fullscreen/163/69482d3...ac928e1.html" title="Last updated on Jan 29, 2020, 11:43 AM UTC (ac928e1)">Diff</a>