### PR TITLE
Meta: wrap algorithms in <div algorithm>

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -77,6 +77,7 @@ its <a>node document</a>'s <a>top layer</a>.
 
 <hr>
 
+<div algorithm>
 <p>To <dfn>fully exit fullscreen</dfn> a <a for=/>document</a> <var>document</var>, run these steps:
 
 <ol>
@@ -88,7 +89,9 @@ its <a>node document</a>'s <a>top layer</a>.
 
  <li><p><a>Exit fullscreen</a> <var>document</var>.
 </ol>
+</div>
 
+<div algorithm="fullscreen removing steps">
 <p id=removing-steps>Whenever the <a>removing steps</a> run with a <var>removedNode</var>, run
 these steps:
 
@@ -110,13 +113,14 @@ these steps:
 
    <li>
     <p>If <var>document</var>'s <a>top layer</a> <a for=set>contains</a> <var>node</var>,
-    <a for=set>remove</a> <var>node</var> from <var>document</var>'s <var>top layer</var>.
+    <a for=set>remove</a> <var>node</var> from <var>document</var>'s <a>top layer</a>.
 
     <p class=note>Other specifications can add and remove elements from <a>top layer</a>, so
     <var>node</var> might not be <var>document</var>'s <a>fullscreen element</a>. For example,
     <var>node</var> could be an open <{dialog}> element.
   </ol>
 </ol>
+</div>
 
 <p>Whenever the <a>unloading document cleanup steps</a> run with a <var>document</var>,
 <a>fully exit fullscreen</a> <var>document</var>.
@@ -128,6 +132,7 @@ security risk, or platform limitation.
 
 <hr>
 
+<div algorithm>
 <p>To <dfn>run the fullscreen steps</dfn> for a <a>document</a> <var>document</var>, run these
 steps:
 
@@ -150,6 +155,7 @@ steps:
 </ol>
 
 <p class=note>These steps integrate with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
+</div>
 
 
 
@@ -227,6 +233,7 @@ if all of the following are true, and false otherwise:
  <!-- cross-process, recursive -->
 </ul>
 
+<div algorithm>
 <p>The <dfn method for=Element><code>requestFullscreen(<var>options</var>)</code></dfn> method,
 when invoked, must run these steps:
 
@@ -352,6 +359,7 @@ when invoked, must run these steps:
 
 <p class=note>Implementations with out-of-process <a for=/>browsing contexts</a> are left as an
 exercise to the reader. Input welcome on potential improvements.
+</div>
 
 <p>The <dfn attribute for=Document><code>fullscreenEnabled</code></dfn> attribute's getter must
 return true if the <a>context object</a> is <a>allowed to use</a> the "<code><a
@@ -363,6 +371,7 @@ false if <a>context object</a>'s <a>fullscreen element</a> is null, and true oth
 
 <p class=note>Use the {{DocumentOrShadowRoot/fullscreenElement}} attribute instead.
 
+<div algorithm>
 <p>The
 <dfn attribute for=DocumentOrShadowRoot id=dom-document-fullscreenelement><code>fullscreenElement</code></dfn>
 attribute's getter must run these steps:
@@ -379,6 +388,7 @@ attribute's getter must run these steps:
 
  <li><p>Return null.
 </ol>
+</div>
 
 <p>A <a>document</a> is said to be a <dfn>simple fullscreen document</dfn> if there is exactly one
 <a>element</a> in its <a>top layer</a> that has its <a>fullscreen flag</a> set.
@@ -387,6 +397,7 @@ attribute's getter must run these steps:
 <a>simple fullscreen document</a>. For example, in addition to the <a>fullscreen element</a> there
 could be an open <{dialog}> element.
 
+<div algorithm>
 <p>To <dfn>collect documents to unfullscreen</dfn> given <var>doc</var>, run these steps:
 
 <ol>
@@ -417,7 +428,9 @@ could be an open <{dialog}> element.
  have more than one <a>element</a> in its <a>top layer</a> with the <a>fullscreen flag</a> set,
  in which case that document will still remain in fullscreen.
 </ol>
+</div>
 
+<div algorithm>
 <p>To <dfn>exit fullscreen</dfn> a <a for=/>document</a> <var>doc</var>, run these steps:
 
 <ol>
@@ -496,6 +509,7 @@ could be an open <{dialog}> element.
 
  <li><p>Resolve <var>promise</var> with undefined.
 </ol>
+</div>
 
 <p>The <dfn method for=Document><code>exitFullscreen()</code></dfn> method, when invoked, must
 return the result of running <a>exit fullscreen</a> on the <a>context object</a>.


### PR DESCRIPTION
This is to enable the scoping/highlighting of variables, and revealed
one mistaken use of "top layer" as a variable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/174.html" title="Last updated on Jun 11, 2020, 3:31 PM UTC (bc45f57)">Preview</a> | <a href="https://whatpr.org/fullscreen/174/b1cfc66...bc45f57.html" title="Last updated on Jun 11, 2020, 3:31 PM UTC (bc45f57)">Diff</a>