### PR TITLE
Link to `Permissions-Policy` header after renaming

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -725,8 +725,8 @@ user agent or even operating system environment when fullscreen. See also the de
 <p>To enable content in a <a>nested browsing context</a> to go fullscreen, it needs to be
 specifically allowed via feature policy, either through the <{iframe/allowfullscreen}> attribute of
 the HTML <{iframe}> element, or an appropriate declaration in the <{iframe/allow}> attribute of the
-HTML <{iframe}> element, or through a `<a http-header><code>Feature-Policy</code></a>` HTTP header
-delivered with the <a>document</a> through which it is nested.
+HTML <{iframe}> element, or through a `<a http-header><code>Permissions-Policy</code></a>` HTTP
+header delivered with the <a>document</a> through which it is nested.
 
 <p>This prevents e.g. content from third parties to go fullscreen without explicit permission.
 


### PR DESCRIPTION
Follows https://github.com/w3c/webappsec-feature-policy/pull/379.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/178.html" title="Last updated on Jun 29, 2020, 1:43 PM UTC (fe6acc6)">Preview</a> | <a href="https://whatpr.org/fullscreen/178/8415b76...fe6acc6.html" title="Last updated on Jun 29, 2020, 1:43 PM UTC (fe6acc6)">Diff</a>