### PR TITLE
Review Draft Publication: January 2021

### DIFF
--- a/review-drafts/2021-01.bs
+++ b/review-drafts/2021-01.bs
@@ -1,5 +1,6 @@
 <pre class=metadata>
 Group: WHATWG
+Date: 2021-01-18
 H1: Fullscreen API
 Shortname: fullscreen
 Text Macro: TWITTER fullscreenapi


### PR DESCRIPTION
The [January 2021 Review Draft](https://fullscreen.spec.whatwg.org/review-drafts/2021-01/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/190.html" title="Last updated on Jan 18, 2021, 4:54 PM UTC (ab67815)">Preview</a> | <a href="https://whatpr.org/fullscreen/190/eb6bc34...ab67815.html" title="Last updated on Jan 18, 2021, 4:54 PM UTC (ab67815)">Diff</a>