### PR TITLE
Hide popovers when making an element fullscreen

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -64,7 +64,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 <p>To <dfn>fullscreen an <var>element</var></dfn>:
 
 <ol>
- <li><p>Run <a>hide all popovers</a>.
+ <li><p>Run <a>hide all popovers</a> given <var>element</var>'s <a>node document</a>.
 
  <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -239,7 +239,7 @@ if all of the following are true, and false otherwise:
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
 
- <li><p><var>element</var>'s <a>popover visibility state</a> is not <a for="popover visibility state">showing</a>.
+ <li><p><var>element</var>'s <a>popover visibility state</a> is <a for="popover visibility state">hidden</a>.
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -239,7 +239,7 @@ if all of the following are true, and false otherwise:
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
 
- <li><p><var>element</var> is not in the <a for="popover visibility state" lt="showing">popover showing state</a>.
+ <li><p><var>element</var>'s <a>popover visibility state</a> is not <a for="popover visibility state">showing</a>.
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -70,9 +70,10 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 <ol>
  <li><p>Run {hide all pop-ups until} given null, false, and false.
 
- <li><p>Set <var>element</var>'s <a>fullscreen flag</a>
+ <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
 
- <li><p><a for="top layer">add</a> it to its <a>node document</a>'s <a>top layer</a>.
+ <li><p><a for="top layer">Add</a> <var>element</var> to <var>element</var>'s <a>node document</a>'s
+ <a>top layer</a>.
 </ol>
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -68,7 +68,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 <p>To <dfn>fullscreen an <var>element</var></dfn>:
 
 <ol>
- <li><p>Run {hide all pop-ups until} given null, false, and true.
+ <li><p>Run {hide all pop-ups until} given null, false, and false.
 
  <li><p>Set <var>element</var>'s <a>fullscreen flag</a>
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -64,7 +64,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 <p>To <dfn>fullscreen an <var>element</var></dfn>:
 
 <ol>
- <li><p>Run {hide all popovers}.
+ <li><p>Run <a>hide all popovers</a>.
 
  <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -239,7 +239,7 @@ if all of the following are true, and false otherwise:
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
 
- <li><p><var>element</var> is not in the <a>popover showing state</a>.
+ <li><p><var>element</var> is not in the <a for="popover visibility state" lt="showing">popover showing state</a>.
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -239,7 +239,7 @@ if all of the following are true, and false otherwise:
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
 
- <li><p><var>element</var> is not in the [=popover showing state=].
+ <li><p><var>element</var> is not in the {popover showing state}.
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -242,7 +242,7 @@ if all of the following are true, and false otherwise:
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
 
- <li><p><var>element</var> is not in the {{popover showing state}}.
+ <li><p><var>element</var> is not in the [=popover showing state=].
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -239,7 +239,7 @@ if all of the following are true, and false otherwise:
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
 
- <li><p><var>element</var> is not in the {popover showing state}.
+ <li><p><var>element</var> is not in the <a>popover showing state</a>.
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -239,7 +239,7 @@ if all of the following are true, and false otherwise:
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
 
- <li><p><var>element</var>'s <a>popover visibility state</a> is <a for="popover visibility state">hidden</a>.
+ <li><p><var>element</var> <a for=Element>namespace</a> is not the <a>HTML namespace</a> or <var>element</var>'s <a>popover visibility state</a> is <a for="popover visibility state">hidden</a>.
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -241,6 +241,8 @@ if all of the following are true, and false otherwise:
  <li><p><var>element</var>'s <a>node document</a> is <a>allowed to use</a> the "<code><a
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
+
+ <li><p><var>element</var> is not in the {{popover showing state}}.
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -239,7 +239,9 @@ if all of the following are true, and false otherwise:
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
 
- <li><p><var>element</var> <a for=Element>namespace</a> is not the <a>HTML namespace</a> or <var>element</var>'s <a>popover visibility state</a> is <a for="popover visibility state">hidden</a>.
+ <li><p><var>element</var> <a for=Element>namespace</a> is not the <a>HTML namespace</a> or
+ <var>element</var>'s <a>popover visibility state</a> is <a for="popover visibility
+ state">hidden</a>.
 </ul>
 
 <div algorithm="requestFullscreen(options)">

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -68,7 +68,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 <p>To <dfn>fullscreen an <var>element</var></dfn>:
 
 <ol>
- <li><p>Run {hide all pop-ups until} given null, false, and false.
+ <li><p>Run {hide all popovers}.
 
  <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -65,8 +65,15 @@ stated otherwise it is unset.
 <p>All <a for=/>documents</a> have an associated <dfn>list of pending fullscreen events</dfn>, which
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
-<p>To <dfn>fullscreen an <var>element</var></dfn>, set <var>element</var>'s <a>fullscreen flag</a>
-and <a for="top layer">add</a> it to its <a>node document</a>'s <a>top layer</a>.
+<p>To <dfn>fullscreen an <var>element</var></dfn>:
+
+<ol>
+ <li><p>Run {hide all pop-ups until} given null, false, and true.
+
+ <li><p>Set <var>element</var>'s <a>fullscreen flag</a>
+
+ <li><p><a for="top layer">add</a> it to its <a>node document</a>'s <a>top layer</a>.
+</ol>
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
 <a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and <a for=set>remove</a> it from


### PR DESCRIPTION
This is part of the new popover attribute: https://github.com/whatwg/html/pull/8221

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chrome
   * …
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/html/semantics/popovers/popover-top-layer-combinations.html
   * https://wpt.fyi/results/html/semantics/popovers/popover-top-layer-interactions.html
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Implemented
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1827225
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=255232
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/204.html" title="Last updated on May 1, 2023, 2:56 PM UTC (4d375fe)">Preview</a> | <a href="https://whatpr.org/fullscreen/204/a69e295...4d375fe.html" title="Last updated on May 1, 2023, 2:56 PM UTC (4d375fe)">Diff</a>