### PR TITLE
Unlock the screen orientation when exiting fullscreen

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -18,6 +18,12 @@ spec:infra
     type:dfn; text:string
 </pre>
 
+<pre class=anchors>
+urlPrefix: https://w3c.github.io/screen-orientation/#dfn-
+    type: dfn
+        text: triggered by a user generated orientation change
+</pre>
+
 <pre class=biblio>
 {
     "CSS": {
@@ -260,7 +266,8 @@ are:
 
    <li><p><a>Fullscreen is supported</a>.
 
-   <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a>.
+   <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a> or the
+   algorithm is <a>triggered by a user generated orientation change</a>.
   </ul>
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -18,12 +18,6 @@ spec:infra
     type:dfn; text:string
 </pre>
 
-<pre class=anchors>
-urlPrefix: https://w3c.github.io/screen-orientation/#dfn-
-    type: dfn
-        text: triggered by a user generated orientation change
-</pre>
-
 <pre class=biblio>
 {
     "CSS": {
@@ -87,7 +81,6 @@ its <a>node document</a>'s <a>top layer</a>.
  <li><p><a lt="unfullscreen an element">Unfullscreen elements</a> whose <a>fullscreen flag</a> is
  set, within <var>document</var>'s <a>top layer</a>, except for <var>document</var>'s
  <a>fullscreen element</a>.
-
  <li><p><a>Exit fullscreen</a> <var>document</var>.
 </ol>
 </div>
@@ -266,8 +259,7 @@ are:
 
    <li><p><a>Fullscreen is supported</a>.
 
-   <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a> or the
-   algorithm is <a>triggered by a user generated orientation change</a>.
+   <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a>.
   </ul>
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
@@ -464,6 +456,8 @@ could be an open <{dialog}> element.
   </ol>
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
+
+ <li><p>Run the [=fully unlock orientation steps=] with <var>doc</var>.
 
  <li><p>If <var>resize</var> is true, resize <var>doc</var>'s viewport to its "normal" dimensions.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -81,6 +81,7 @@ its <a>node document</a>'s <a>top layer</a>.
  <li><p><a lt="unfullscreen an element">Unfullscreen elements</a> whose <a>fullscreen flag</a> is
  set, within <var>document</var>'s <a>top layer</a>, except for <var>document</var>'s
  <a>fullscreen element</a>.
+
  <li><p><a>Exit fullscreen</a> <var>document</var>.
 </ol>
 </div>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -457,7 +457,7 @@ could be an open <{dialog}> element.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
- <li><p>Run the [=fully unlock orientation steps=] with <var>doc</var>.
+ <li><p>Run the [=fully unlock the screen orientation steps=] with <var>doc</var>.
 
  <li><p>If <var>resize</var> is true, resize <var>doc</var>'s viewport to its "normal" dimensions.
 


### PR DESCRIPTION
Closes #202

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [X] At least two implementers are interested (and none opposed):
   * Interested in WebKit (and bug filed)
   * Implemented in Chrome 
   * bug filed for Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * http://wpt.live/screen-orientation/fullscreen-interactions.html
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: already implemented (confirmed on Chrome Android). 
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1798646.
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=247250
- [X] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/whatwg/fullscreen/pull/206#issuecomment-1306572664

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/206.html" title="Last updated on Nov 14, 2022, 5:19 AM UTC (07cd6c6)">Preview</a> | <a href="https://whatpr.org/fullscreen/206/38e9b40...07cd6c6.html" title="Last updated on Nov 14, 2022, 5:19 AM UTC (07cd6c6)">Diff</a>