### PR TITLE
DRAFT PROPOSAL: Pre-apply orientation lock via FullscreenOptions

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -172,6 +172,7 @@ enum FullscreenNavigationUI {
 
 dictionary FullscreenOptions {
   FullscreenNavigationUI navigationUI = "auto";
+  OrientationLockType orientation;
 };
 
 partial interface Element {
@@ -209,6 +210,11 @@ partial interface mixin DocumentOrShadowRoot {
   set to "{{FullscreenNavigationUI/hide}}", more screen space is preferred. User agents are always
   free to honor user preference over the application's. The default value
   "{{FullscreenNavigationUI/auto}}" indicates no application preference.
+
+  When supplied, <var>options</var>'s {{FullscreenOptions/orientation}} member indicates whether
+  the screen should be locked to the given [=screen orientation=]. User agents are always
+  free to honor user preference over the application's. When the value is missing,
+  no orientation lock is applied.
 
  <dt><code><var>document</var> . {{Document/fullscreenEnabled}}</code>
  <dd><p>Returns true if <var>document</var> has the ability to display <a>elements</a> fullscreen
@@ -275,7 +281,8 @@ are:
  <li>
   <p>If <var>error</var> is false, then resize <var>pendingDoc</var>'s
   <a>top-level browsing context</a>'s <a>active document</a>'s viewport's dimensions, optionally
-  taking into account <var>options</var>["{{FullscreenOptions/navigationUI}}"]:
+  taking into account <var>options</var>["{{FullscreenOptions/orientation}}"] and
+  <var>options</var>["{{FullscreenOptions/navigationUI}}"]:
   <!-- cross-process -->
 
   <table>


### PR DESCRIPTION
Seeking feedback on this draft proposal from implementers. 

The potential advantages with this proposal are numerous:

 * Potentially smoother visual transition when switching to fullscreen. 
 * Releasing the orientation is explicitly tied to exiting fullscreen (per #202)
 * Easier to use than Screen Orientation Lock API, while also working together with it (via events, and also allowing orientation changes after going fullscreen). 

Addresses #186 

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
