### PR TITLE
Rely solely on transient activation for orientation events

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -18,12 +18,6 @@ spec:infra
     type:dfn; text:string
 </pre>
 
-<pre class=anchors>
-urlPrefix: https://w3c.github.io/screen-orientation/#dfn-
-    type: dfn
-        text: triggered by a user generated orientation change
-</pre>
-
 <pre class=biblio>
 {
     "CSS": {
@@ -262,8 +256,7 @@ are:
 
    <li><p><a>Fullscreen is supported</a>.
 
-   <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a> or the
-   algorithm is <a>triggered by a user generated orientation change</a>.
+   <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a>.
   </ul>
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.


### PR DESCRIPTION
Please see:
https://github.com/whatwg/html/issues/8490

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * Chrome implements this behavior (in that they special case screen orientation change events to call `.requestFullscreen()`).
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
