### PR TITLE
Editorial: use inset property in the UA style sheet

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -676,7 +676,7 @@ properties apply to this pseudo-element either.
 
 *|*:not(:root):fullscreen {
   position:fixed !important;
-  top:0 !important; right:0 !important; bottom:0 !important; left:0 !important;
+  inset:0 !important;
   margin:0 !important;
   box-sizing:border-box !important;
   min-width:0 !important;
@@ -698,7 +698,7 @@ iframe:fullscreen {
 
 ::backdrop {
   position:fixed;
-  top:0; right:0; bottom:0; left:0;
+  inset:0;
 }
 
 *|*:not(:root):fullscreen::backdrop {


### PR DESCRIPTION
Fixes https://github.com/whatwg/fullscreen/issues/201.

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium (proposed by @mfreed7)
   * Gecko (@emilio [comment](https://github.com/whatwg/fullscreen/issues/201#issuecomment-1230813781))
   * WebKit (@annevk [comment](https://github.com/whatwg/fullscreen/issues/201#issuecomment-1230504035))
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * This isn't observable since the computed style is the same both before and after, so no test updates.
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1393369
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1802334
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=248310
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/210.html" title="Last updated on Nov 24, 2022, 4:26 PM UTC (1bf58af)">Preview</a> | <a href="https://whatpr.org/fullscreen/210/4a1f34a...1bf58af.html" title="Last updated on Nov 24, 2022, 4:26 PM UTC (1bf58af)">Diff</a>