### PR TITLE
Remove top layer definitions, now that CSS Position 4 contains them.

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -64,13 +64,21 @@ stated otherwise it is unset.
 <p>All <a for=/>documents</a> have an associated <dfn>list of pending fullscreen events</dfn>, which
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
-<p>To <dfn>fullscreen an <var>element</var></dfn>, set <var>element</var>'s <a>fullscreen flag</a>.
-<a>Request removal from the top layer</a> given |element|'s <a>node document</a> and |element|, then
-<a>add to the top layer</a> given |element|'s <a>node document</a> and |element|.
+<p>To <dfn>fullscreen an <var>element</var></dfn>:
+
+<ol>
+ <li><p>Run <a>hide all popovers</a> given <var>element</var>'s <a>node document</a>.
+
+ <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
+
+ <li><p><a>Request removal from the top layer</a> given <var>element</var>.
+
+ <li><a>Add to the top layer</a> given <var>element</var>.
+</ol>
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
 <a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and
-<a>remove from the top layer immediately</a> given |element|'s <a>node document</a> and |element|.
+<a>remove from the top layer immediately</a> given <var>element</var>.
 
 <p>To <dfn>unfullscreen a <var>document</var></dfn>,
 <a lt="unfullscreen an element">unfullscreen</a> all <a>elements</a>, within <var>document</var>'s
@@ -114,7 +122,7 @@ these steps:
 
    <li>
     <p>If <var>document</var>'s <a>top layer</a> <a for=set>contains</a> <var>node</var>,
-    <a>remove from the top layer immediately</a> given <var>document</var> and <var>node</var>.
+    <a>remove from the top layer immediately</a> given <var>node</var>.
 
     <p class=note>Other specifications can add and remove elements from <a>top layer</a>, so
     <var>node</var> might not be <var>document</var>'s <a>fullscreen element</a>. For example,
@@ -234,6 +242,10 @@ if all of the following are true, and false otherwise:
  <li><p><var>element</var>'s <a>node document</a> is <a>allowed to use</a> the "<code><a
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
+
+ <li><p><var>element</var> <a for=Element>namespace</a> is not the <a>HTML namespace</a> or
+ <var>element</var>'s <a>popover visibility state</a> is <a for="popover visibility
+ state">hidden</a>.
 </ul>
 
 <div algorithm="requestFullscreen(options)">
@@ -269,6 +281,9 @@ are:
    <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a> or the
    algorithm is <a>triggered by a user generated orientation change</a>.
   </ul>
+
+ <li><p>If <var>error</var> is false, then <a>consume user activation</a> given
+ <var>pendingDoc</var>'s <a>relevant global object</a>.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -72,7 +72,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 
 <p>To <dfn>unfullscreen a <var>document</var></dfn>,
 <a lt="unfullscreen an element">unfullscreen</a> all <a>elements</a>, within <var>document</var>'s
-[=Document/top layer=], whose <a>fullscreen flag</a> is set.
+<a for=Document>top layer</a>, whose <a>fullscreen flag</a> is set.
 
 <hr>
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -660,6 +660,7 @@ allow="fullscreen *"&gt;</code>, as described in
 </div>
 
 
+
 <h2 id=security-and-privacy-considerations>Security and Privacy Considerations</h2>
 
 <p>User agents should ensure, e.g. by means of an overlay, that the end user is aware something is
@@ -675,6 +676,7 @@ allowed via permissions policy, either through the <{iframe/allowfullscreen}> at
 delivered with the <a>document</a> through which it is nested.
 
 <p>This prevents e.g. content from third parties to go fullscreen without explicit permission.
+
 
 
 <h2 id=old-links class=no-num oldids="new-stacking-layer, top-layer, top-layer-add, ::backdrop-pseudo-element, css-pe-backdrop">Previously-hosted definitions</h2>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -677,8 +677,7 @@ delivered with the <a>document</a> through which it is nested.
 <p>This prevents e.g. content from third parties to go fullscreen without explicit permission.
 
 
-<h2 id=old-links class=no-num oldids="new-stacking-layer, top-layer, top-layer-add, ::backdrop-pseudo-element, css-pe-backdrop">
-Appendix A: Previously-Hosted Definitions</h2>
+<h2 id=old-links class=no-num oldids="new-stacking-layer, top-layer, top-layer-add, ::backdrop-pseudo-element, css-pe-backdrop">Previously-hosted definitions</h2>
 
 This specification previously hosted the definitions of <a selector>::backdrop</a>
 and the concept of the document's <a>top layer</a>.

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -16,7 +16,9 @@ spec:dom
 spec:infra
     type:dfn; for:set; text:for each
     type:dfn; text:string
-spec:css-position-4; type:selector; text: ::backdrop
+spec:css-position-4
+    type:selector; text: ::backdrop
+    type:dfn; text:top layer
 </pre>
 
 <pre class=anchors>
@@ -57,30 +59,22 @@ stated otherwise it is unset.
 
 <p>All <a for=/>documents</a> have an associated <dfn export>fullscreen element</dfn>. The
 <a>fullscreen element</a> is the topmost <a>element</a> in the <a for=/>document</a>'s
-<a for=Document>top layer</a> whose <a>fullscreen flag</a> is set, if any, and null otherwise.
+<a>top layer</a> whose <a>fullscreen flag</a> is set, if any, and null otherwise.
 
 <p>All <a for=/>documents</a> have an associated <dfn>list of pending fullscreen events</dfn>, which
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
-<p>To <dfn>fullscreen an <var>element</var></dfn>:
-
-<ol>
- <li><p>Run <a>hide all popovers</a> given <var>element</var>'s <a>node document</a>.
-
- <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
-
- <li><p><a>Request removal from the top layer</a> given <var>element</var>.
-
- <li><a>Add to the top layer</a> given <var>element</var>.
-</ol>
+<p>To <dfn>fullscreen an <var>element</var></dfn>, set <var>element</var>'s <a>fullscreen flag</a>.
+<a>Request removal from the top layer</a> given |element|'s <a>node document</a> and |element|, then
+<a>add to the top layer</a> given |element|'s <a>node document</a> and |element|.
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
 <a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and
-<a>remove from the top layer immediately</a> given <var>element</var>.
+<a>remove from the top layer immediately</a> given |element|'s <a>node document</a> and |element|.
 
 <p>To <dfn>unfullscreen a <var>document</var></dfn>,
 <a lt="unfullscreen an element">unfullscreen</a> all <a>elements</a>, within <var>document</var>'s
-<a for=Document>top layer</a>, whose <a>fullscreen flag</a> is set.
+<a>top layer</a>, whose <a>fullscreen flag</a> is set.
 
 <hr>
 
@@ -91,7 +85,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
  <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, terminate these steps.
 
  <li><p><a lt="unfullscreen an element">Unfullscreen elements</a> whose <a>fullscreen flag</a> is
- set, within <var>document</var>'s <a for=Document>top layer</a>, except for <var>document</var>'s
+ set, within <var>document</var>'s <a>top layer</a>, except for <var>document</var>'s
  <a>fullscreen element</a>.
 
  <li><p><a>Exit fullscreen</a> <var>document</var>.
@@ -119,10 +113,10 @@ these steps:
    <li><p>Otherwise, <a lt="unfullscreen an element">unfullscreen <var>node</var></a>.
 
    <li>
-    <p>If <var>document</var>'s <a for=Document>top layer</a> <a for=set>contains</a> <var>node</var>,
-    <a>remove from the top layer immediately</a> given <var>node</var>.
+    <p>If <var>document</var>'s <a>top layer</a> <a for=set>contains</a> <var>node</var>,
+    <a>remove from the top layer immediately</a> given <var>document</var> and <var>node</var>.
 
-    <p class=note>Other specifications can add and remove elements from <a for=Document>top layer</a>, so
+    <p class=note>Other specifications can add and remove elements from <a>top layer</a>, so
     <var>node</var> might not be <var>document</var>'s <a>fullscreen element</a>. For example,
     <var>node</var> could be an open <{dialog}> element.
   </ol>
@@ -240,10 +234,6 @@ if all of the following are true, and false otherwise:
  <li><p><var>element</var>'s <a>node document</a> is <a>allowed to use</a> the "<code><a
  data-lt="fullscreen-feature">fullscreen</a></code>" feature.
  <!-- cross-process, recursive -->
-
- <li><p><var>element</var> <a for=Element>namespace</a> is not the <a>HTML namespace</a> or
- <var>element</var>'s <a>popover visibility state</a> is <a for="popover visibility
- state">hidden</a>.
 </ul>
 
 <div algorithm="requestFullscreen(options)">
@@ -279,9 +269,6 @@ are:
    <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a> or the
    algorithm is <a>triggered by a user generated orientation change</a>.
   </ul>
-
- <li><p>If <var>error</var> is false, then <a>consume user activation</a> given
- <var>pendingDoc</var>'s <a>relevant global object</a>.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
@@ -417,9 +404,9 @@ getter steps are:
 </div>
 
 <p>A <a>document</a> is said to be a <dfn>simple fullscreen document</dfn> if there is exactly one
-<a>element</a> in its <a for=Document>top layer</a> that has its <a>fullscreen flag</a> set.
+<a>element</a> in its <a>top layer</a> that has its <a>fullscreen flag</a> set.
 
-<p class=note>A <a>document</a> with two <a>elements</a> in its <a for=Document>top layer</a> can be a
+<p class=note>A <a>document</a> with two <a>elements</a> in its <a>top layer</a> can be a
 <a>simple fullscreen document</a>. For example, in addition to the <a>fullscreen element</a> there
 could be an open <{dialog}> element.
 
@@ -453,7 +440,7 @@ could be an open <{dialog}> element.
 
  <p class=note>This is the set of documents for which the <a>fullscreen element</a> will be
  <a lt="unfullscreen an element">unfullscreened</a>, but the last document in <var>docs</var> might
- have more than one <a>element</a> in its <a for=Document>top layer</a> with the <a>fullscreen flag</a> set,
+ have more than one <a>element</a> in its <a>top layer</a> with the <a>fullscreen flag</a> set,
  in which case that document will still remain in fullscreen.
 </ol>
 </div>
@@ -679,7 +666,7 @@ delivered with the <a>document</a> through which it is nested.
 Appendix A: Previously-Hosted Definitions</h2>
 
 This specification previously hosted the definitions of <a selector>::backdrop</a>
-and the concept of the document's <a for=Document>top layer</a>.
+and the concept of the document's <a>top layer</a>.
 
 
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -665,7 +665,7 @@ delivered with the <a>document</a> through which it is nested.
 Appendix A: Previously-Hosted Definitions</h2>
 
 This specification previously hosted the definitions of <a selector>::backdrop</a>
-and the concept of the [=Document/top layer=].
+and the concept of the document's [=Document/top layer=].
 
 
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -71,7 +71,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 
  <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
 
- <li><p><a>Request removal from the top layer</a> given <var>element</var>.
+ <li><p><a>Remove from the top layer immediately</a> given <var>element</var>.
 
  <li><a>Add to the top layer</a> given <var>element</var>.
 </ol>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -69,14 +69,14 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 
  <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
 
- <li><p><a>Request removal from the top layer</a> given |element|'s <a>node document</a> and |element|.
+ <li><p><a>Request removal from the top layer</a> given <var>element</var>.
 
- <li><a>Add to the top layer</a> given |element|'s <a>node document</a> and |element|.
+ <li><a>Add to the top layer</a> given <var>element</var>.
 </ol>
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
 <a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and
-<a>remove from the top layer immediately</a> given |element|'s <a>node document</a> and |element|.
+<a>remove from the top layer immediately</a> given <var>element</var>.
 
 <p>To <dfn>unfullscreen a <var>document</var></dfn>,
 <a lt="unfullscreen an element">unfullscreen</a> all <a>elements</a>, within <var>document</var>'s
@@ -120,7 +120,7 @@ these steps:
 
    <li>
     <p>If <var>document</var>'s <a for=Document>top layer</a> <a for=set>contains</a> <var>node</var>,
-    <a>remove from the top layer immediately</a> given <var>document</var> and <var>node</var>.
+    <a>remove from the top layer immediately</a> given <var>node</var>.
 
     <p class=note>Other specifications can add and remove elements from <a for=Document>top layer</a>, so
     <var>node</var> might not be <var>document</var>'s <a>fullscreen element</a>. For example,

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -7,7 +7,6 @@ Text Macro: LATESTRD 2023-01
 Abstract: The Fullscreen API standard defines an API for elements to display themselves fullscreen.
 Translation: ja https://triple-underscore.github.io/fullscreen-ja.html
 Markup Shorthands: css no
-Ignore MDN Failure: ::backdrop-pseudo-element
 </pre>
 
 <pre class=link-defaults>
@@ -17,6 +16,7 @@ spec:dom
 spec:infra
     type:dfn; for:set; text:for each
     type:dfn; text:string
+spec:css-position-4; type:selector; text: ::backdrop
 </pre>
 
 <pre class=anchors>
@@ -659,6 +659,13 @@ allowed via permissions policy, either through the <{iframe/allowfullscreen}> at
 delivered with the <a>document</a> through which it is nested.
 
 <p>This prevents e.g. content from third parties to go fullscreen without explicit permission.
+
+
+<h2 id=old-links class=no-num oldids="new-stacking-layer, top-layer, top-layer-add, ::backdrop-pseudo-element, css-pe-backdrop">
+Appendix A: Previously-Hosted Definitions</h2>
+
+This specification previously hosted the definitions of <a selector>::backdrop</a>
+and the concept of the [=Document/top layer=].
 
 
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -63,7 +63,7 @@ stated otherwise it is unset.
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
 <p>To <dfn>fullscreen an <var>element</var></dfn>, set <var>element</var>'s <a>fullscreen flag</a>.
-If <var>element</var> is not currently in its <a>node document</a>'s [=Document/top layer=],
+If <var>element</var> is not currently [=in the top layer=] of its <a>node document</a>,
 [=add to the top layer|add it to the top layer=] of its <a>node document</a>.
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -68,7 +68,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
 <a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and
-<a>request removal from the top layer</a> for it from its <a>node document</a>.
+<a>remove from the top layer immediately</a> given |element|'s <a>node document</a> and |element|.
 
 <p>To <dfn>unfullscreen a <var>document</var></dfn>,
 <a lt="unfullscreen an element">unfullscreen</a> all <a>elements</a>, within <var>document</var>'s

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -7,6 +7,7 @@ Text Macro: LATESTRD 2023-01
 Abstract: The Fullscreen API standard defines an API for elements to display themselves fullscreen.
 Translation: ja https://triple-underscore.github.io/fullscreen-ja.html
 Markup Shorthands: css no
+Ignore MDN Failure: ::backdrop-pseudo-element
 </pre>
 
 <pre class=link-defaults>
@@ -56,21 +57,22 @@ stated otherwise it is unset.
 
 <p>All <a for=/>documents</a> have an associated <dfn export>fullscreen element</dfn>. The
 <a>fullscreen element</a> is the topmost <a>element</a> in the <a for=/>document</a>'s
-<a>top layer</a> whose <a>fullscreen flag</a> is set, if any, and null otherwise.
+[=Document/top layer=] whose <a>fullscreen flag</a> is set, if any, and null otherwise.
 
 <p>All <a for=/>documents</a> have an associated <dfn>list of pending fullscreen events</dfn>, which
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
-<p>To <dfn>fullscreen an <var>element</var></dfn>, set <var>element</var>'s <a>fullscreen flag</a>
-and <a for="top layer">add</a> it to its <a>node document</a>'s <a>top layer</a>.
+<p>To <dfn>fullscreen an <var>element</var></dfn>, set <var>element</var>'s <a>fullscreen flag</a>.
+If <var>element</var> is not currently in its <a>node document</a>'s [=Document/top layer=],
+[=add to the top layer|add it to the top layer=] of its <a>node document</a>.
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
-<a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and <a for=set>remove</a> it from
-its <a>node document</a>'s <a>top layer</a>.
+<a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and
+<a>request removal from the top layer</a> for it from its <a>node document</a>.
 
 <p>To <dfn>unfullscreen a <var>document</var></dfn>,
 <a lt="unfullscreen an element">unfullscreen</a> all <a>elements</a>, within <var>document</var>'s
-<a>top layer</a>, whose <a>fullscreen flag</a> is set.
+[=Document/top layer=], whose <a>fullscreen flag</a> is set.
 
 <hr>
 
@@ -81,7 +83,7 @@ its <a>node document</a>'s <a>top layer</a>.
  <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, terminate these steps.
 
  <li><p><a lt="unfullscreen an element">Unfullscreen elements</a> whose <a>fullscreen flag</a> is
- set, within <var>document</var>'s <a>top layer</a>, except for <var>document</var>'s
+ set, within <var>document</var>'s [=Document/top layer=], except for <var>document</var>'s
  <a>fullscreen element</a>.
 
  <li><p><a>Exit fullscreen</a> <var>document</var>.
@@ -109,10 +111,11 @@ these steps:
    <li><p>Otherwise, <a lt="unfullscreen an element">unfullscreen <var>node</var></a>.
 
    <li>
-    <p>If <var>document</var>'s <a>top layer</a> <a for=set>contains</a> <var>node</var>,
-    <a for=set>remove</a> <var>node</var> from <var>document</var>'s <a>top layer</a>.
+    <p>If <var>document</var>'s [=Document/top layer=] <a for=set>contains</a> <var>node</var>,
+    <a>remove from the top layer immediately</a> <var>node</var> from <var>document</var>'s
+    [=Document/top layer=].
 
-    <p class=note>Other specifications can add and remove elements from <a>top layer</a>, so
+    <p class=note>Other specifications can add and remove elements from [=Document/top layer=], so
     <var>node</var> might not be <var>document</var>'s <a>fullscreen element</a>. For example,
     <var>node</var> could be an open <{dialog}> element.
   </ol>
@@ -400,9 +403,9 @@ getter steps are:
 </div>
 
 <p>A <a>document</a> is said to be a <dfn>simple fullscreen document</dfn> if there is exactly one
-<a>element</a> in its <a>top layer</a> that has its <a>fullscreen flag</a> set.
+<a>element</a> in its [=Document/top layer=] that has its <a>fullscreen flag</a> set.
 
-<p class=note>A <a>document</a> with two <a>elements</a> in its <a>top layer</a> can be a
+<p class=note>A <a>document</a> with two <a>elements</a> in its [=Document/top layer=] can be a
 <a>simple fullscreen document</a>. For example, in addition to the <a>fullscreen element</a> there
 could be an open <{dialog}> element.
 
@@ -436,7 +439,7 @@ could be an open <{dialog}> element.
 
  <p class=note>This is the set of documents for which the <a>fullscreen element</a> will be
  <a lt="unfullscreen an element">unfullscreened</a>, but the last document in <var>docs</var> might
- have more than one <a>element</a> in its <a>top layer</a> with the <a>fullscreen flag</a> set,
+ have more than one <a>element</a> in its [=Document/top layer=] with the <a>fullscreen flag</a> set,
  in which case that document will still remain in fullscreen.
 </ol>
 </div>
@@ -570,88 +573,6 @@ or call to {{Document/exitFullscreen()}} whenever the user agent deems it necess
 
 <p>This section is to be interpreted equivalently to the Rendering section of HTML. [[!HTML]]
 
-<p class=XXX>Long term CSS will define the <a>top layer</a> concept and its associated
-<a><code>::backdrop</code></a> pseudo-element as part of CSS' stacking context model. Patching CSS
-as done here is sketchy as hell.
-
-
-<h3 id=new-stacking-layer>New stacking layer</h3>
-
-<p>This specification introduces a new stacking layer to the
-<a href=https://www.w3.org/TR/CSS2/zindex.html>Elaborate description of Stacking Contexts</a> of CSS
-2.1. It is called the <dfn export>top layer</dfn>, comes after step 10 in the painting order, and is
-therefore rendered closest to the user within a viewport. Each <a for=/>document</a> has one
-associated viewport and therefore also one <a>top layer</a>. [[!CSS]]
-
-<p class=note>The terminology used in this and following subsection attempts to match CSS 2.1
-Appendix E.
-
-<p>The <a>top layer</a> is an <a>ordered set</a> of elements, rendered in the order they appear in
-the set. The last element in the set is rendered last, and thus appears on top.
-
-<p class=note>The <code>z-index</code> property has no effect in the <a>top layer</a>.
-
-<p>Each element and <a><code>::backdrop</code></a> pseudo-element in a <a>top layer</a> has the
-following characteristics:
-
-<ul>
- <li><p>It generates a new stacking context.
-
- <li><p>Its parent stacking context is the root stacking context.
-
- <li><p>If it consists of multiple layout boxes, the first box is used.
- <!-- https://www.w3.org/Bugs/Public/show_bug.cgi?id=24523 -->
-
- <li>
-  <p>It is rendered as an atomic unit as if it were a sibling of its <a for=tree>root</a>.
-
-  <p class=note><a for=tree>Ancestor</a> elements with overflow, opacity, masks, etc. cannot affect
-  it.
-
- <li><p>If its <code>position</code> property computes to <code>fixed</code>, its containing block
- is the viewport, and the initial containing block otherwise.
-
- <li><p>If it is an element, it and its <a><code>::backdrop</code></a> pseudo-element are not
- rendered if its <a>shadow-including inclusive ancestor</a> has the <code>display</code> property
- set to <code>none</code>.
-
- <li><p>If its specified <code>display</code> property is <code>contents</code>, it computes to
- <code>block</code>.
-
- <li><p>If its specified <code>position</code> property is not <code>absolute</code> or
- <code>fixed</code>, it computes to <code>absolute</code>.
-
- <li><p>Its outline, if any, is to be rendered before step 10 in the painting order.
-
- <li><p>Unless overridden by another specification, its static position for <code>left</code>,
- <code>right</code>, and <code>top</code> is zero.
-</ul>
-
-<p>To <dfn export for="top layer">add</dfn> an <var>element</var> to a <var>top layer</var>,
-<a for=set>remove</a> it from <var>top layer</var> and then <a for=set>append</a> it to
-<var>top layer</var>.
-
-<p class=note>In other words, <var>element</var> is moved to the end of <var>top layer</var> if it
-is already present.
-
-
-<h3 id=::backdrop-pseudo-element><code>::backdrop</code> pseudo-element</h3>
-
-<p>Each element in a <a>top layer</a> has a
-<dfn id=css-pe-backdrop selector><code>::backdrop</code></dfn> pseudo-element. This pseudo-element
-is a box rendered immediately below the element (and above the element before the element in the
-set, if any), within the same <a>top layer</a>.
-
-<p class=note>The <a><code>::backdrop</code></a> pseudo-element can be used to create a backdrop
-that hides the underlying document for an element in a <a>top layer</a> (such as an element that is
-displayed fullscreen).
-
-<p>It does not inherit from any element and is not inherited from. No restrictions are made on what
-properties apply to this pseudo-element either.
-
-<!-- That this is not in a more normative prose is because CSS should have hooks for this stuff
-     which make it normative. -->
-
 
 <h3 id=:fullscreen-pseudo-class><code>:fullscreen</code> pseudo-class</h3>
 
@@ -694,11 +615,6 @@ properties apply to this pseudo-element either.
 iframe:fullscreen {
   border:none !important;
   padding:0 !important;
-}
-
-::backdrop {
-  position:fixed;
-  inset:0;
 }
 
 *|*:not(:root):fullscreen::backdrop {
@@ -776,7 +692,7 @@ Riff Jiang,
 Rune Lillesveen,
 Sigbjørn Vik,
 Simon Pieters,
-Tab Atkins,
+Tab Atkins-Bittner,
 Takayoshi Kochi,
 Theresa O'Connor,
 triple-underscore,

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -63,8 +63,8 @@ stated otherwise it is unset.
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
 <p>To <dfn>fullscreen an <var>element</var></dfn>, set <var>element</var>'s <a>fullscreen flag</a>.
-If <var>element</var> is not currently [=in the top layer=] of its <a>node document</a>,
-[=add to the top layer|add it to the top layer=] of its <a>node document</a>.
+[=Request removal from the top layer=] for |element| from its [=node document=], then
+[=add to the top layer|add it to the top layer=] of its [=node document=].
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
 <a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -57,14 +57,14 @@ stated otherwise it is unset.
 
 <p>All <a for=/>documents</a> have an associated <dfn export>fullscreen element</dfn>. The
 <a>fullscreen element</a> is the topmost <a>element</a> in the <a for=/>document</a>'s
-[=Document/top layer=] whose <a>fullscreen flag</a> is set, if any, and null otherwise.
+<a for=Document>top layer</a> whose <a>fullscreen flag</a> is set, if any, and null otherwise.
 
 <p>All <a for=/>documents</a> have an associated <dfn>list of pending fullscreen events</dfn>, which
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
 <p>To <dfn>fullscreen an <var>element</var></dfn>, set <var>element</var>'s <a>fullscreen flag</a>.
-[=Request removal from the top layer=] for |element| from its [=node document=], then
-[=add to the top layer|add it to the top layer=] of its [=node document=].
+<a>Request removal from the top layer</a> given |element|'s <a>node document</a> and |element|, then
+<a>add to the top layer</a> given |element|'s <a>node document</a> and |element|.
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
 <a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and
@@ -83,7 +83,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
  <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, terminate these steps.
 
  <li><p><a lt="unfullscreen an element">Unfullscreen elements</a> whose <a>fullscreen flag</a> is
- set, within <var>document</var>'s [=Document/top layer=], except for <var>document</var>'s
+ set, within <var>document</var>'s <a for=Document>top layer</a>, except for <var>document</var>'s
  <a>fullscreen element</a>.
 
  <li><p><a>Exit fullscreen</a> <var>document</var>.
@@ -111,11 +111,10 @@ these steps:
    <li><p>Otherwise, <a lt="unfullscreen an element">unfullscreen <var>node</var></a>.
 
    <li>
-    <p>If <var>document</var>'s [=Document/top layer=] <a for=set>contains</a> <var>node</var>,
-    <a>remove from the top layer immediately</a> <var>node</var> from <var>document</var>'s
-    [=Document/top layer=].
+    <p>If <var>document</var>'s <a for=Document>top layer</a> <a for=set>contains</a> <var>node</var>,
+    <a>remove from the top layer immediately</a> given <var>document</var> and <var>node</var>.
 
-    <p class=note>Other specifications can add and remove elements from [=Document/top layer=], so
+    <p class=note>Other specifications can add and remove elements from <a for=Document>top layer</a>, so
     <var>node</var> might not be <var>document</var>'s <a>fullscreen element</a>. For example,
     <var>node</var> could be an open <{dialog}> element.
   </ol>
@@ -403,9 +402,9 @@ getter steps are:
 </div>
 
 <p>A <a>document</a> is said to be a <dfn>simple fullscreen document</dfn> if there is exactly one
-<a>element</a> in its [=Document/top layer=] that has its <a>fullscreen flag</a> set.
+<a>element</a> in its <a for=Document>top layer</a> that has its <a>fullscreen flag</a> set.
 
-<p class=note>A <a>document</a> with two <a>elements</a> in its [=Document/top layer=] can be a
+<p class=note>A <a>document</a> with two <a>elements</a> in its <a for=Document>top layer</a> can be a
 <a>simple fullscreen document</a>. For example, in addition to the <a>fullscreen element</a> there
 could be an open <{dialog}> element.
 
@@ -439,7 +438,7 @@ could be an open <{dialog}> element.
 
  <p class=note>This is the set of documents for which the <a>fullscreen element</a> will be
  <a lt="unfullscreen an element">unfullscreened</a>, but the last document in <var>docs</var> might
- have more than one <a>element</a> in its [=Document/top layer=] with the <a>fullscreen flag</a> set,
+ have more than one <a>element</a> in its <a for=Document>top layer</a> with the <a>fullscreen flag</a> set,
  in which case that document will still remain in fullscreen.
 </ol>
 </div>
@@ -665,7 +664,7 @@ delivered with the <a>document</a> through which it is nested.
 Appendix A: Previously-Hosted Definitions</h2>
 
 This specification previously hosted the definitions of <a selector>::backdrop</a>
-and the concept of the document's [=Document/top layer=].
+and the concept of the document's <a for=Document>top layer</a>.
 
 
 


### PR DESCRIPTION
Also reword algos as appropriate.

As far as Fullscreen is concerned, this is *almost* a no-op change, as things are merely moving. The only normative change that's relevant here is in the "fullscreen an element" algo, as it's no longer valid to add something to the top layer when it's already there (see next para for details). At the moment I've changed it to simply check if it's already in the top layer and only add if it's not, but this can be changed as necessary. (There are some other changes to the top-layer handling as it exists in Position 4, but they're in response to CSSWG decisions and are being discussed over there.)

The issue with adding something to the top layer that's already there is that, now that we have multiple things interacting with the top layer, they can have complex interactions of their own, and arbitrarily rearranging an element put in the top layer by some other process isn't necessarily safe. For example, a popover can be part of a popover stack, with each attached to the element below. Fullscreening the bottom popover *must not* just move that bottom popover to the end of the top layer and leave the rest of the popovers behind; it has to do *something* else, probably closing the popover (and thus closing its associated stack).

I'm not 100% sure how we want to handle the interaction of these separate features. I *suspect* it'll have to be something like each defining its own "hey you're being removed from the top layer" algo, which the others can invoke before they add the element to the top layer for their own purposes. But this'll need more thought; I went with what I felt was the simplest model for right now, where if you fullscreen something already in the top layer for other reasons, it just gets its flag and that's that.

(This is technically a behavior change per spec, but doesn't appear to be a behavior change in practice, at least in Chrome - if you fullscreen an element, show a modal, then ask to fullscreen the first element again, it *does not* move on top of the dialog, it stays where it is. But opening a dialog *then* fullscreening an element does successfully put the fullscreen over the dialog. I'm having trouble getting Firefox to successfully fullscreen something so I can test this.)

/cc @mfreed7 @josepharhar @nt1m @annevk 

-------

Currently this PR won't build because I'm using a new Bikeshed metadata to ignore the MDN issue; I should have a release out supporting this new metadata either today or tomorrow. (It won't build *without* the metadata either, since it's a fatal error to be missing an MDN anchor, too.).

Potentially we could kill both by keeping the ID in the spec, but just having it explicitly say that the definition has been moved to CSS Position. Would that be better?

More generally, for all the IDs that are being moved to Position, do you want to keep them in the spec with a redirect section?

-------

- [ ] At least two implementers are interested (and none opposed):
   * Chrome
   * ?
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/39828
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: Already Chrome's behavior.
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1834542
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=257199
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: <https://github.com/mdn/browser-compat-data/issues/19367> for redirecting ::backdrop to Position; don't *think* anything else needs tweaking.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/223.html" title="Last updated on May 23, 2023, 2:53 PM UTC (2ff6c60)">Preview</a> | <a href="https://whatpr.org/fullscreen/223/afd56a3...2ff6c60.html" title="Last updated on May 23, 2023, 2:53 PM UTC (2ff6c60)">Diff</a>