### PR TITLE
Add keyboard locking option

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -195,7 +195,7 @@ enum FullscreenNavigationUI {
 };
 
 enum FullscreenKeyboardLock {
-  "application",
+  "browser",
   "none",
   "system"
 };
@@ -245,7 +245,7 @@ partial interface mixin DocumentOrShadowRoot {
   When supplied, <var>options</var>'s {{FullscreenOptions/keyboardLock}} member indicates whether
   the supplied keyboard lock mode should apply.
 
-  If set to "{{FullscreenKeyboardLock/application}}", [=application-level keyboard lock=] should
+  If set to "{{FullscreenKeyboardLock/browser}}", [=application-level keyboard lock=] should
   be applied.
 
   If set to "{{FullscreenKeyboardLock/system}}", [=system-level keyboard lock=] should be applied.
@@ -423,7 +423,7 @@ are:
   <li>
   Depending on the value of {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}:
   <dl switch>
-    <dt>"{{FullscreenKeyboardLock/application}}"</dt>
+    <dt>"{{FullscreenKeyboardLock/browser}}"</dt>
     <dd><p>Apply an [=application-level keyboard lock=].
     <dt>"{{FullscreenKeyboardLock/system}}"</dt>
     <dd><p>Apply a [=system-level keyboard lock=].
@@ -709,7 +709,7 @@ like ESC or function keys are integral to the application's functionality.
 
 <p>A <dfn>keyboard lock</dfn> enables web applications to capture and handle key inputs directly,
 bypassing the default behavior typically executed by the user agent (in the case of
-"{{FullscreenKeyboardLock/application}}") or operating system (in the case of
+"{{FullscreenKeyboardLock/browser}}") or operating system (in the case of
 "{{FullscreenKeyboardLock/system}}"). When the [=keyboard lock flag=] is set for a [=document=], key
 events that would normally trigger user agent or system-level actions are instead redirected to the
 web application in fullscreen.

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -376,7 +376,7 @@ are:
   </ol>
 
  <li>
-  If, {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}'s value is not supported,
+  If {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}'s value is not supported,
   reject <var>promise</var> with a {{NotSupportedError}} exception and terminate these
   steps.
  </li>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -432,10 +432,10 @@ are:
 
   <dl class=switch>
    <dt>"{{FullscreenKeyboardLock/browser}}"</dt>
-   <dd><p>Set the [=keyboard lock flag=] for <a>this</a> to true.
+   <dd><p>Se <a>this</a>'s [=keyboard lock flag=].
 
    <dt>"{{FullscreenKeyboardLock/none}}"</dt>
-   <dd><p>Set the [=keyboard lock flag=] for <a>this</a> to false.
+   <dd><p>Unset <a>this</a>'s [=keyboard lock flag=].
   </dl>
 
  <li><p>Resolve <var>promise</var> with undefined.

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -87,9 +87,9 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
  <li><a>Add to the top layer</a> given <var>element</var>.
 </ol>
 
-<p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
-<a>fullscreen flag</a>, <a>iframe fullscreen flag</a> (if any), and <a>keyboard lock flag</a>, and
-<a>remove from the top layer immediately</a> given <var>element</var>.
+<p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s <a>fullscreen
+flag</a>, <a>iframe fullscreen flag</a> (if any), and <a>keyboard lock flag</a>, and <a>remove from
+the top layer immediately</a> given <var>element</var>.
 
 <p>To <dfn>unfullscreen a <var>document</var></dfn>,
 <a lt="unfullscreen an element">unfullscreen</a> all <a>elements</a>, within <var>document</var>'s
@@ -180,9 +180,11 @@ steps:
 
 <hr>
 
-<p>All <a>elements</a> have an associated <dfn>keyboard lock flag</dfn>. Unless stated otherwise it is unset.
+<p>All <a>elements</a> have an associated <dfn>keyboard lock flag</dfn>. Unless stated otherwise it
+is unset.
 
-<p>A [=document=] has <dfn>keyboard lock</dfn> active when its [=fullscreen element=] is not null and the [=fullscreen element=]'s [=keyboard lock flag=] is true, and inactive otherwise.
+<p>A [=document=] has <dfn>keyboard lock</dfn> active when its [=fullscreen element=] is not null
+and the [=fullscreen element=]'s [=keyboard lock flag=] is true, and inactive otherwise.
 
 <div algorithm>
   <p>To <dfn>run the release the keyboard lock steps</dfn> for a <a>document</a>
@@ -191,9 +193,11 @@ steps:
   <ol>
     <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, then return.
 
-    <li><p>If the [=keyboard lock flag=] for <var>document</var>'s <a>fullscreen element</a> is false, then return.
+    <li><p>If the [=keyboard lock flag=] for <var>document</var>'s <a>fullscreen element</a> is
+    false, then return.
 
-    <li><p>Set the [=keyboard lock flag=] for <var>document</var>'s <a>fullscreen element</a> to false.
+    <li><p>Set the [=keyboard lock flag=] for <var>document</var>'s <a>fullscreen element</a> to
+    false.
   </ol>
 </div>
 
@@ -716,7 +720,9 @@ fullscreen. Such key events (for individual keys or keyboard shortcuts) may eith
 while [=keyboard lock=] is active, or it could still have the same action but allow the web page to
 call {{Event/preventDefault()}} to cancel the action.
 
-<p>Whenever a [=document=]'s [=keyboard lock=] is changed from active to inactive, user agents must deactivate the keyboard lock and restore the handling of keyboard inputs to the default behavior of the user agent and the operating system.
+<p>Whenever a [=document=]'s [=keyboard lock=] is changed from active to inactive, user agents must
+deactivate the keyboard lock and restore the handling of keyboard inputs to the default behavior of
+the user agent and the operating system.
 
 <p>User agents should reserve an additional input for the purposes of exiting fullscreen. There are
 also some system-level key sequences or combinations that cannot be intercepted for security
@@ -766,7 +772,11 @@ system control or privacy risks (like Alt+Tab, Ctrl+Alt+Del), can be locked via 
 <p>When applying a [=keyboard lock=], user agents should implement safeguards to prevent abuse of
 this feature, such as allowing users to override the lock.
 
-<p>User agents may provide a user preference to ignore [=keyboard lock=] (with any granularity, e.g. for a specific site, or globally). Similarly, some platforms might not have a keyboard, where user agents may ignore the [=keyboard lock=] state. However, this should not affect the web-observable behavior of the {{Element/requestFullscreen()}} method or be exposed in other ways, to avoid fingerprinting.
+<p>User agents may provide a user preference to ignore [=keyboard lock=] (with any granularity, e.g.
+for a specific site, or globally). Similarly, some platforms might not have a keyboard, where user
+agents may ignore the [=keyboard lock=] state. However, this should not affect the web-observable
+behavior of the {{Element/requestFullscreen()}} method or be exposed in other ways, to avoid
+fingerprinting.
 
 
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -16,6 +16,7 @@ spec:dom
     type:dfn; for:/; text:document
     type:dfn; for:/; text:element
     type:interface; text:Document
+    type:dfn; text:removing steps
 spec:infra
     type:dfn; for:set; text:for each
     type:dfn; text:string

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -184,20 +184,19 @@ steps:
 is unset.
 
 <p>A [=document=] has <dfn>keyboard lock</dfn> active when its [=fullscreen element=] is not null
-and the [=fullscreen element=]'s [=keyboard lock flag=] is true, and inactive otherwise.
+and the [=fullscreen element=]'s [=keyboard lock flag=] is set, and inactive otherwise.
 
 <div algorithm>
-  <p>To <dfn>run the release the keyboard lock steps</dfn> for a <a>document</a>
-  <var>document</var>, run these steps:
+  <p>To <dfn>release the keyboard lock</dfn> for a <a>document</a> <var>document</var>, run these
+  steps:
 
   <ol>
     <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, then return.
 
-    <li><p>If the [=keyboard lock flag=] for <var>document</var>'s <a>fullscreen element</a> is
-    false, then return.
+    <li><p>If <var>document</var>'s <a>fullscreen element</a>'s [=keyboard lock flag=] is unset,
+    then return.
 
-    <li><p>Set the [=keyboard lock flag=] for <var>document</var>'s <a>fullscreen element</a> to
-    false.
+    <li><p>Unset <var>document</var>'s <a>fullscreen element</a>'s [=keyboard lock flag=].
   </ol>
 </div>
 
@@ -553,7 +552,7 @@ could be an open <{dialog}> element.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
- <li><p>[=Run the release the keyboard lock steps=] with <var>doc</var>.
+ <li><p>[=Release the keyboard lock=] for <var>doc</var>.
 
  <li><p>Run the [=fully unlock the screen orientation steps=] with <var>doc</var>.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -183,8 +183,8 @@ steps:
 <p>All <a>elements</a> have an associated <dfn>keyboard lock flag</dfn>. Unless stated otherwise it
 is unset.
 
-<p>A [=document=] has <dfn>keyboard lock</dfn> active when its [=fullscreen element=] is not null
-and the [=fullscreen element=]'s [=keyboard lock flag=] is set, and inactive otherwise.
+<p>A <a>document</a> has <dfn>keyboard lock</dfn> active when its <a>fullscreen element</a> is not
+null and the <a>fullscreen element</a>'s <a>keyboard lock flag</a> is set, and inactive otherwise.
 
 <div algorithm>
   <p>To <dfn>release the keyboard lock</dfn> for a <a>document</a> <var>document</var>, run these
@@ -193,10 +193,10 @@ and the [=fullscreen element=]'s [=keyboard lock flag=] is set, and inactive oth
   <ol>
     <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, then return.
 
-    <li><p>If <var>document</var>'s <a>fullscreen element</a>'s [=keyboard lock flag=] is unset,
+    <li><p>If <var>document</var>'s <a>fullscreen element</a>'s <a>keyboard lock flag</a> is unset,
     then return.
 
-    <li><p>Unset <var>document</var>'s <a>fullscreen element</a>'s [=keyboard lock flag=].
+    <li><p>Unset <var>document</var>'s <a>fullscreen element</a>'s <a>keyboard lock flag</a>.
   </ol>
 </div>
 
@@ -258,7 +258,7 @@ partial interface mixin DocumentOrShadowRoot {
   When supplied, <var>options</var>'s {{FullscreenOptions/keyboardLock}} member indicates whether
   the supplied keyboard lock mode will apply.
 
-  If set to "{{FullscreenKeyboardLock/browser}}", [=keyboard lock=] can be applied.
+  If set to "{{FullscreenKeyboardLock/browser}}", <a>keyboard lock</a> can be applied.
 
   User agents are always free to honor user preference over the application's. The default value
   "{{FullscreenKeyboardLock/none}}" indicates no keyboard lock is applied.
@@ -432,10 +432,10 @@ are:
 
   <dl class=switch>
    <dt>"{{FullscreenKeyboardLock/browser}}"</dt>
-   <dd><p>Set <a>this</a>'s [=keyboard lock flag=].
+   <dd><p>Set <a>this</a>'s <a>keyboard lock flag</a>.
 
    <dt>"{{FullscreenKeyboardLock/none}}"</dt>
-   <dd><p>Unset <a>this</a>'s [=keyboard lock flag=].
+   <dd><p>Unset <a>this</a>'s <a>keyboard lock flag</a>.
   </dl>
 
  <li><p>Resolve <var>promise</var> with undefined.
@@ -552,9 +552,9 @@ could be an open <{dialog}> element.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
- <li><p>[=Release the keyboard lock=] for <var>doc</var>.
+ <li><p><a>Release the keyboard lock</a> for <var>doc</var>.
 
- <li><p>Run the [=fully unlock the screen orientation steps=] with <var>doc</var>.
+ <li><p>Run the <a>fully unlock the screen orientation steps</a> with <var>doc</var>.
 
  <li><p>If <var>resize</var> is true, resize <var>doc</var>'s viewport to its "normal" dimensions.
 
@@ -643,8 +643,8 @@ algorithm as part of the <a>close request steps</a>. This takes precedence over 
 <p>The user agent may end any fullscreen session without a <a>close request</a> or call to
 {{Document/exitFullscreen()}} whenever the user agent deems it necessary.
 
-<p>Users should be clearly notified when [=keyboard locking=] is active, possibly through browser UI
-indicators.
+<p>Users should be clearly notified when <a>keyboard locking</a> is active, possibly through browser
+UI indicators.
 
 <p>There should be a simple and intuitive method for users to override keyboard locking, reverting
 control back to the system or user agent.
@@ -712,16 +712,16 @@ them to intercept certain key inputs that would typically be handled by either t
 user agent. This is useful in scenarios such as gaming or remote desktop applications, where keys
 like ESC or function keys are integral to the application's functionality.
 
-<p>A [=keyboard lock=] enables web applications to capture and handle key inputs directly, bypassing
-the default behavior typically executed by the user agent or operating system. Key events that would
-normally trigger user agent or system-level actions are instead redirected to the web application in
-fullscreen. Such key events (for individual keys or keyboard shortcuts) may either have no action
-while [=keyboard lock=] is active, or it could still have the same action but allow the web page to
-call {{Event/preventDefault()}} to cancel the action.
+<p>A <a>keyboard lock</a> enables web applications to capture and handle key inputs directly,
+bypassing the default behavior typically executed by the user agent or operating system. Key events
+that would normally trigger user agent or system-level actions are instead redirected to the web
+application in fullscreen. Such key events (for individual keys or keyboard shortcuts) may either
+have no action while <a>keyboard lock</a> is active, or it could still have the same action but
+allow the web page to call {{Event/preventDefault()}} to cancel the action.
 
-<p>Whenever a [=document=]'s [=keyboard lock=] is changed from active to inactive, user agents must
-deactivate the keyboard lock and restore the handling of keyboard inputs to the default behavior of
-the user agent and the operating system.
+<p>Whenever a <a>document</a>'s <a>keyboard lock</a> is changed from active to inactive, user agents
+must deactivate the keyboard lock and restore the handling of keyboard inputs to the default
+behavior of the user agent and the operating system.
 
 <p>User agents should reserve an additional input for the purposes of exiting fullscreen. There are
 also some system-level key sequences or combinations that cannot be intercepted for security
@@ -765,17 +765,17 @@ delivered with the <a>document</a> through which it is nested.
 
 <p>This prevents e.g. content from third parties to go fullscreen without explicit permission.
 
-<p>When applying a [=keyboard lock=], only a limited set of keys, primarily those not involving
+<p>When applying a <a>keyboard lock</a>, only a limited set of keys, primarily those not involving
 system control or privacy risks (like Alt+Tab, Ctrl+Alt+Del), can be locked via the API.
 
-<p>When applying a [=keyboard lock=], user agents should implement safeguards to prevent abuse of
+<p>When applying a <a>keyboard lock</a>, user agents should implement safeguards to prevent abuse of
 this feature, such as allowing users to override the lock.
 
-<p>User agents may provide a user preference to ignore [=keyboard lock=] (with any granularity, e.g.
-for a specific site, or globally). Similarly, some platforms might not have a keyboard, where user
-agents may ignore the [=keyboard lock=] state. However, this should not affect the web-observable
-behavior of the {{Element/requestFullscreen()}} method or be exposed in other ways, to avoid
-fingerprinting.
+<p>User agents may provide a user preference to ignore <a>keyboard lock</a> (with any granularity,
+e.g. for a specific site, or globally). Similarly, some platforms might not have a keyboard, where
+user agents may ignore the <a>keyboard lock</a> state. However, this should not affect the
+web-observable behavior of the {{Element/requestFullscreen()}} method or be exposed in other ways,
+to avoid fingerprinting.
 
 
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -64,9 +64,9 @@ stated otherwise it is unset.
 
 <p>All <a for=/>documents</a> have an associated <dfn>keyboard lock flag</dfn>. This flag indicates
 whether the keyboard lock is active for the document. When the flag is set, the document captures
-and handles key inputs as specified by a passed {{FullscreenKeyboardLock}} enum value. When the
-flag is not set, keyboard inputs are processed in the default manner by the user agent and the
-operating system. Unless stated otherwise it is unset.
+and handles key inputs as specified by a passed {{FullscreenKeyboardLock}} enum value. When the flag
+is not set, keyboard inputs are processed in the default manner by the user agent and the operating
+system. Unless stated otherwise it is unset.
 
 <p>All <a for=/>documents</a> have an associated <dfn export>fullscreen element</dfn>. The
 <a>fullscreen element</a> is the topmost <a>element</a> in the <a for=/>document</a>'s
@@ -197,8 +197,7 @@ enum FullscreenNavigationUI {
 
 enum FullscreenKeyboardLock {
   "browser",
-  "none",
-  "system"
+  "none"
 };
 
 dictionary FullscreenOptions {
@@ -245,9 +244,7 @@ partial interface mixin DocumentOrShadowRoot {
   When supplied, <var>options</var>'s {{FullscreenOptions/keyboardLock}} member indicates whether
   the supplied keyboard lock mode will apply.
 
-  If set to "{{FullscreenKeyboardLock/browser}}", [=application-level keyboard lock=] can be applied.
-
-  If set to "{{FullscreenKeyboardLock/system}}", [=system-level keyboard lock=] can be applied.
+  If set to "{{FullscreenKeyboardLock/browser}}", [=keyboard lock=] can be applied.
 
   User agents are always free to honor user preference over the application's. The default value
   "{{FullscreenKeyboardLock/none}}" indicates no keyboard lock is applied.
@@ -375,9 +372,8 @@ are:
   </ol>
 
  <li>
-  If {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}'s value is not supported,
-  reject <var>promise</var> with a {{NotSupportedError}} exception and terminate these
-  steps.
+  If {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}'s value is not supported, reject
+  <var>promise</var> with a {{NotSupportedError}} exception and terminate these steps.
  </li>
 
  <li><p>Let <var>fullscreenElements</var> be an <a>ordered set</a> initially consisting of
@@ -423,9 +419,7 @@ are:
   Depending on the value of {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}:
   <dl switch>
     <dt>"{{FullscreenKeyboardLock/browser}}"</dt>
-    <dd><p>Apply an [=application-level keyboard lock=].
-    <dt>"{{FullscreenKeyboardLock/system}}"</dt>
-    <dd><p>Apply a [=system-level keyboard lock=].
+    <dd><p>Set the [=keyboard lock flag=] for <var>doc</var> to true.
   </dl>
  </li>
 
@@ -637,8 +631,8 @@ algorithm as part of the <a>close request steps</a>. This takes precedence over 
 <p>The user agent may end any fullscreen session without a <a>close request</a> or call to
 {{Document/exitFullscreen()}} whenever the user agent deems it necessary.
 
-<p>Users should be clearly notified when [=keyboard locking=] is active, possibly through browser
-UI indicators.
+<p>Users should be clearly notified when [=keyboard locking=] is active, possibly through browser UI
+indicators.
 
 <p>There should be a simple and intuitive method for users to override keyboard locking, reverting
 control back to the system or user agent.
@@ -706,36 +700,31 @@ them to intercept certain key inputs that would typically be handled by either t
 user agent. This is useful in scenarios such as gaming or remote desktop applications, where keys
 like ESC or function keys are integral to the application's functionality.
 
-<p>A <dfn>keyboard lock</dfn> enables web applications to capture and handle key inputs directly,
-bypassing the default behavior typically executed by the user agent (in the case of
-"{{FullscreenKeyboardLock/browser}}") or operating system (in the case of
-"{{FullscreenKeyboardLock/system}}"). When the [=keyboard lock flag=] is set for a [=document=], key
-events that would normally trigger user agent or system-level actions are instead redirected to the
-web application in fullscreen.
+<p>A [=document=] has <dfn>keyboard lock</dfn> active when the [=keyboard lock flag=] is true for a
+[=document=], and inactive otherwise.
 
-<dl>
-  <dt><dfn>Application-level keyboard lock</dfn></dt>
-  <dd><p>Captures all keys that the user agent would ordinarily receive, such as those that open or
-  close windows. This excludes those reserved for system-level interactions, such
-  as key presses that open system menus or switch applications.
-  <dt><dfn>System-level keyboard lock</dfn></dt>
-  <dd><p>Capture a wider range of keys, including those used for system-level navigation and
-  shortcuts (e.g., Alt+Tab), subject to user consent and user agent implementation.
-</dl>
+<p>A [=keyboard lock=] enables web applications to capture and handle key inputs directly, bypassing
+the default behavior typically executed by the user agent or operating system. Key events that would
+normally trigger user agent or system-level actions are instead redirected to the web application in
+fullscreen. Such key events (for individual keys or keyboard shortcuts) may either have no action
+while [=keyboard lock=] is active, or it could still have the same action but allow the web page to
+call {{Event/preventDefault()}} to cancel the action.
 
-<p>User agents should reserve an additional input for the purposes of exiting fullscreen.
-There are also some system-level key sequences or combinations that cannot be
-intercepted for security reasons, such as Ctrl+Alt+Del on Windows.
+<p>User agents should reserve an additional input for the purposes of exiting fullscreen. There are
+also some system-level key sequences or combinations that cannot be intercepted for security
+reasons, such as Ctrl+Alt+Del on Windows.
 
 <div algorithm>
   <p>To <dfn>run the release the keyboard lock steps</dfn> for a <a>document</a>
   <var>document</var>, run these steps:
+
   <ol>
-    <li><p>If the [=keyboard lock flag=] for the <var>document</var> is not set, abort these steps.
+    <li><p>If the [=keyboard lock flag=] for <var>document</var> is not set, then return.
+
     <li><p>Deactivate the keyboard lock and restore the handling of keyboard inputs to the default
     behavior of the user agent and the operating system.
-    <li><p>Set the [=keyboard lock flag=] for
-    the <var>document</var> to <code>false</code>.
+
+    <li><p>Set the [=keyboard lock flag=] for <var>document</var> to false.
   </ol>
 </div>
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -198,7 +198,7 @@ enum FullscreenKeyboardLock {
   "application",
   "none",
   "system"
-}
+};
 
 dictionary FullscreenOptions {
   FullscreenKeyboardLock keyboardLock = "none";
@@ -547,7 +547,7 @@ could be an open <{dialog}> element.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
- <li><p>Run [=the release the keyboard lock steps=] with <var>doc</var>.
+ <li><p>[=Run the release the keyboard lock steps=] with <var>doc</var>.
 
  <li><p>Run the [=fully unlock the screen orientation steps=] with <var>doc</var>.
 
@@ -700,7 +700,7 @@ iframe:fullscreen {
 
 
 
-<h2>keyboard lock</h2>
+<h2 id="keyboard-locking">keyboard locking</h2>
 
 <p>keyboard Locking enhances the functionality of web applications running in fullscreen by allowing
 them to intercept certain key inputs that would typically be handled by either the system or the
@@ -723,6 +723,16 @@ web application in fullscreen.
   shortcuts (e.g., Alt+Tab), subject to user consent and user agent implementation.
 </dl>
 
+<div algorithm>
+  <p>To <dfn>run the release the keyboard lock steps</dfn> for a <a>document</a>
+  <var>document</var>, run these steps:
+  <ol>
+    <li><p>If the [=keyboard lock flag=] for the <var>document</var> is not set, abort these steps.
+    <li><p>Deactivate the keyboard lock and restore the handling of keyboard inputs to the default
+    behavior of the user agent and the operating system. <li><p>Set the [=keyboard lock flag=] for
+    the <var>document</var> to <code>false</code>.
+  </ol>
+</div>
 
 <h2 id=permissions-policy-integration oldids=feature-policy-integration>Permissions Policy
 Integration</h2>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -415,16 +415,16 @@ are:
    <var>doc</var>'s <a>list of pending fullscreen events</a>.
   </ol>
 
-  <li>
-  Depending on the value of {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}:
-  <dl switch>
-    <dt>"{{FullscreenKeyboardLock/browser}}"</dt>
-    <dd><p>Set the [=keyboard lock flag=] for <var>doc</var> to true.
-  </dl>
- </li>
-
   <p class=note>The order in which elements are <a lt="fullscreen an element">fullscreened</a>
   is not observable, because <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
+
+ <li>
+  <p>Depending on the value of {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}:
+
+  <dl class=switch>
+   <dt>"{{FullscreenKeyboardLock/browser}}"</dt>
+   <dd><p>Set the [=keyboard lock flag=] for <var>doc</var> to true.
+  </dl>
 
  <li><p>Resolve <var>promise</var> with undefined.
 </ol>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -65,7 +65,7 @@ stated otherwise it is unset.
 whether the keyboard lock is active for the document. When the flag is set, the document captures
 and handles key inputs as specified by a passed {{FullscreenKeyboardLock}} enum value. When the
 flag is not set, keyboard inputs are processed in the default manner by the user agent and the
-operating system.
+operating system. Unless stated otherwise it is unset.
 
 <p>All <a for=/>documents</a> have an associated <dfn export>fullscreen element</dfn>. The
 <a>fullscreen element</a> is the topmost <a>element</a> in the <a for=/>document</a>'s

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -711,6 +711,11 @@ behavior of the user agent and the operating system.
 also some system-level key sequences or combinations that cannot be intercepted for security
 reasons, such as Ctrl+Alt+Del on Windows.
 
+<p>For example, user agents that use the Esc key to exit fullscreen use keyboard lock to prevent
+immediate exit on key press, and instead require a long press to exit fullscreen. Some such user
+agents also implicitly grant partial keyboard lock to fullscreen session, in which case the Esc key
+might be the only key that is affected by explicit keyboard lock.
+
 
 <h2 id=permissions-policy-integration oldids=feature-policy-integration>Permissions Policy
 Integration</h2>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -432,7 +432,7 @@ are:
 
   <dl class=switch>
    <dt>"{{FullscreenKeyboardLock/browser}}"</dt>
-   <dd><p>Se <a>this</a>'s [=keyboard lock flag=].
+   <dd><p>Set <a>this</a>'s [=keyboard lock flag=].
 
    <dt>"{{FullscreenKeyboardLock/none}}"</dt>
    <dd><p>Unset <a>this</a>'s [=keyboard lock flag=].

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -150,6 +150,9 @@ these steps:
 <p><dfn>Fullscreen is supported</dfn> if there is no previously-established user preference,
 security risk, or platform limitation.
 
+<p><dfn>Keyboard lock is supported</dfn> if there is no previously-established user preference,
+security risk, or platform limitation.
+
 <hr>
 
 <div algorithm>
@@ -324,6 +327,8 @@ are:
    algorithm is <a>triggered by a user generated orientation change</a>.
   </ul>
 
+ <li><p>If <var>options</var>["{{FullscreenOptions/keyboardLock}}"] is "{{FullscreenKeyboardLock/browser}}" and <a>keyboard lock is supported</a> is false, then set <var>error</var> to true.
+
  <li><p>If <var>error</var> is false, then <a>consume user activation</a> given
  <var>pendingDoc</var>'s <a>relevant global object</a>.
 
@@ -381,9 +386,6 @@ are:
    <li><p>Reject <var>promise</var> with a {{TypeError}} exception and terminate these
    steps.
   </ol>
-
- <li><p>If <var>options</var>["{{FullscreenOptions/keyboardLock}}"] is not supported, then reject
-  <var>promise</var> with a {{NotSupportedError}} exception and terminate these steps.
 
  <li><p>Let <var>fullscreenElements</var> be an <a>ordered set</a> initially consisting of
  <a>this</a>.

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -719,7 +719,7 @@ web application in fullscreen.
   <dd><p>Captures all keys that the user agent would ordinarily receive, except those reserved for
   critical system functions or security shortcuts (e.g., Ctrl+Alt+Del).
   <dt><dfn>System-level keyboard lock</dfn></dt>
-  <dd><p>capture a wider range of keys, including those used for system-level navigation and
+  <dd><p>Capture a wider range of keys, including those used for system-level navigation and
   shortcuts (e.g., Alt+Tab), subject to user consent and user agent implementation.
 </dl>
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -150,9 +150,6 @@ these steps:
 <p><dfn>Fullscreen is supported</dfn> if there is no previously-established user preference,
 security risk, or platform limitation.
 
-<p><dfn>Keyboard lock is supported</dfn> if there is no previously-established user preference,
-security risk, or platform limitation.
-
 <hr>
 
 <div algorithm>
@@ -326,8 +323,6 @@ are:
    <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a> or the
    algorithm is <a>triggered by a user generated orientation change</a>.
   </ul>
-
- <li><p>If <var>options</var>["{{FullscreenOptions/keyboardLock}}"] is "{{FullscreenKeyboardLock/browser}}" and <a>keyboard lock is supported</a> is false, then set <var>error</var> to true.
 
  <li><p>If <var>error</var> is false, then <a>consume user activation</a> given
  <var>pendingDoc</var>'s <a>relevant global object</a>.
@@ -770,6 +765,8 @@ system control or privacy risks (like Alt+Tab, Ctrl+Alt+Del), can be locked via 
 
 <p>When applying a [=keyboard lock=], user agents should implement safeguards to prevent abuse of
 this feature, such as allowing users to override the lock.
+
+<p>User agents may provide a user preference to ignore [=keyboard lock=] (with any granularity, e.g. for a specific site, or globally). Similarly, some platforms might not have a keyboard, where user agents may ignore the [=keyboard lock=] state. However, this should not affect the web-observable behavior of the {{Element/requestFullscreen()}} method or be exposed in other ways, to avoid fingerprinting.
 
 
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -186,20 +186,6 @@ is unset.
 <p>A <a>document</a> has <dfn>keyboard lock</dfn> active when its <a>fullscreen element</a> is not
 null and the <a>fullscreen element</a>'s <a>keyboard lock flag</a> is set, and inactive otherwise.
 
-<div algorithm>
-  <p>To <dfn>release the keyboard lock</dfn> for a <a>document</a> <var>document</var>, run these
-  steps:
-
-  <ol>
-    <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, then return.
-
-    <li><p>If <var>document</var>'s <a>fullscreen element</a>'s <a>keyboard lock flag</a> is unset,
-    then return.
-
-    <li><p>Unset <var>document</var>'s <a>fullscreen element</a>'s <a>keyboard lock flag</a>.
-  </ol>
-</div>
-
 <h2 id=api>API</h2>
 
 <pre class=idl>
@@ -551,8 +537,6 @@ could be an open <{dialog}> element.
   </ol>
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
-
- <li><p><a>Release the keyboard lock</a> for <var>doc</var>.
 
  <li><p>Run the <a>fully unlock the screen orientation steps</a> with <var>doc</var>.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -62,12 +62,6 @@ unset.
 <p>All <{iframe}> <a>elements</a> have an associated <dfn>iframe fullscreen flag</dfn>. Unless
 stated otherwise it is unset.
 
-<p>All <a for=/>documents</a> have an associated <dfn>keyboard lock flag</dfn>. This flag indicates
-whether the keyboard lock is active for the document. When the flag is set, the document captures
-and handles key inputs as specified by a passed {{FullscreenKeyboardLock}} enum value. When the flag
-is not set, keyboard inputs are processed in the default manner by the user agent and the operating
-system. Unless stated otherwise it is unset.
-
 <p>All <a for=/>documents</a> have an associated <dfn export>fullscreen element</dfn>. The
 <a>fullscreen element</a> is the topmost <a>element</a> in the <a for=/>document</a>'s
 <a>top layer</a> whose <a>fullscreen flag</a> is set, if any, and null otherwise.
@@ -94,7 +88,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 </ol>
 
 <p>To <dfn>unfullscreen an <var>element</var></dfn>, unset <var>element</var>'s
-<a>fullscreen flag</a> and <a>iframe fullscreen flag</a> (if any), and
+<a>fullscreen flag</a>, <a>iframe fullscreen flag</a> (if any), and <a>keyboard lock flag</a>, and
 <a>remove from the top layer immediately</a> given <var>element</var>.
 
 <p>To <dfn>unfullscreen a <var>document</var></dfn>,
@@ -184,7 +178,24 @@ steps:
 <p class=note>These steps integrate with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
 </div>
 
+<hr>
 
+<p>All <a>elements</a> have an associated <dfn>keyboard lock flag</dfn>. Unless stated otherwise it is unset.
+
+<p>A [=document=] has <dfn>keyboard lock</dfn> active when its [=fullscreen element=] is not null and the [=fullscreen element=]'s [=keyboard lock flag=] is true, and inactive otherwise.
+
+<div algorithm>
+  <p>To <dfn>run the release the keyboard lock steps</dfn> for a <a>document</a>
+  <var>document</var>, run these steps:
+
+  <ol>
+    <li><p>If <var>document</var>'s <a>fullscreen element</a> is null, then return.
+
+    <li><p>If the [=keyboard lock flag=] for <var>document</var>'s <a>fullscreen element</a> is false, then return.
+
+    <li><p>Set the [=keyboard lock flag=] for <var>document</var>'s <a>fullscreen element</a> to false.
+  </ol>
+</div>
 
 <h2 id=api>API</h2>
 
@@ -371,10 +382,8 @@ are:
    steps.
   </ol>
 
- <li>
-  If {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}'s value is not supported, reject
+ <li><p>If <var>options</var>["{{FullscreenOptions/keyboardLock}}"] is not supported, then reject
   <var>promise</var> with a {{NotSupportedError}} exception and terminate these steps.
- </li>
 
  <li><p>Let <var>fullscreenElements</var> be an <a>ordered set</a> initially consisting of
  <a>this</a>.
@@ -419,11 +428,14 @@ are:
   is not observable, because <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
 
  <li>
-  <p>Depending on the value of {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}:
+  <p>Depending on the value of <var>options</var>["{{FullscreenOptions/keyboardLock}}"]:
 
   <dl class=switch>
    <dt>"{{FullscreenKeyboardLock/browser}}"</dt>
-   <dd><p>Set the [=keyboard lock flag=] for <var>doc</var> to true.
+   <dd><p>Set the [=keyboard lock flag=] for <a>this</a> to true.
+
+   <dt>"{{FullscreenKeyboardLock/none}}"</dt>
+   <dd><p>Set the [=keyboard lock flag=] for <a>this</a> to false.
   </dl>
 
  <li><p>Resolve <var>promise</var> with undefined.
@@ -700,9 +712,6 @@ them to intercept certain key inputs that would typically be handled by either t
 user agent. This is useful in scenarios such as gaming or remote desktop applications, where keys
 like ESC or function keys are integral to the application's functionality.
 
-<p>A [=document=] has <dfn>keyboard lock</dfn> active when the [=keyboard lock flag=] is true for a
-[=document=], and inactive otherwise.
-
 <p>A [=keyboard lock=] enables web applications to capture and handle key inputs directly, bypassing
 the default behavior typically executed by the user agent or operating system. Key events that would
 normally trigger user agent or system-level actions are instead redirected to the web application in
@@ -710,23 +719,12 @@ fullscreen. Such key events (for individual keys or keyboard shortcuts) may eith
 while [=keyboard lock=] is active, or it could still have the same action but allow the web page to
 call {{Event/preventDefault()}} to cancel the action.
 
+<p>Whenever a [=document=]'s [=keyboard lock=] is changed from active to inactive, user agents must deactivate the keyboard lock and restore the handling of keyboard inputs to the default behavior of the user agent and the operating system.
+
 <p>User agents should reserve an additional input for the purposes of exiting fullscreen. There are
 also some system-level key sequences or combinations that cannot be intercepted for security
 reasons, such as Ctrl+Alt+Del on Windows.
 
-<div algorithm>
-  <p>To <dfn>run the release the keyboard lock steps</dfn> for a <a>document</a>
-  <var>document</var>, run these steps:
-
-  <ol>
-    <li><p>If the [=keyboard lock flag=] for <var>document</var> is not set, then return.
-
-    <li><p>Deactivate the keyboard lock and restore the handling of keyboard inputs to the default
-    behavior of the user agent and the operating system.
-
-    <li><p>Set the [=keyboard lock flag=] for <var>document</var> to false.
-  </ol>
-</div>
 
 <h2 id=permissions-policy-integration oldids=feature-policy-integration>Permissions Policy
 Integration</h2>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -61,6 +61,12 @@ unset.
 <p>All <{iframe}> <a>elements</a> have an associated <dfn>iframe fullscreen flag</dfn>. Unless
 stated otherwise it is unset.
 
+<p>All <a for=/>documents</a> have an associated <dfn>keyboard lock flag</dfn>. This flag indicates
+whether the keyboard lock is active for the document. When the flag is set, the document captures
+and handles key inputs as specified by a passed {{FullscreenKeyboardLock}} enum value. When the
+flag is not set, keyboard inputs are processed in the default manner by the user agent and the
+operating system.
+
 <p>All <a for=/>documents</a> have an associated <dfn export>fullscreen element</dfn>. The
 <a>fullscreen element</a> is the topmost <a>element</a> in the <a for=/>document</a>'s
 <a>top layer</a> whose <a>fullscreen flag</a> is set, if any, and null otherwise.
@@ -188,7 +194,14 @@ enum FullscreenNavigationUI {
   "hide"
 };
 
+enum FullscreenKeyboardLock {
+  "application",
+  "none",
+  "system"
+}
+
 dictionary FullscreenOptions {
+  FullscreenKeyboardLock keyboardLock = "none";
   FullscreenNavigationUI navigationUI = "auto";
 };
 
@@ -227,6 +240,18 @@ partial interface mixin DocumentOrShadowRoot {
   set to "{{FullscreenNavigationUI/hide}}", more screen space is preferred. User agents are always
   free to honor user preference over the application's. The default value
   "{{FullscreenNavigationUI/auto}}" indicates no application preference.
+
+ <dd>
+  When supplied, <var>options</var>'s {{FullscreenOptions/keyboardLock}} member indicates whether
+  the supplied keyboard lock mode should apply.
+
+  If set to "{{FullscreenKeyboardLock/application}}", [=application-level keyboard lock=] should
+  be applied.
+
+  If set to "{{FullscreenKeyboardLock/system}}", [=system-level keyboard lock=] should be applied.
+
+  User agents are always free to honor user preference over the application's. The default value
+  "{{FullscreenKeyboardLock/none}}" indicates no keyboard lock is applied.
 
  <dt><code><var>document</var> . {{Document/fullscreenEnabled}}</code>
  <dd><p>Returns true if <var>document</var> has the ability to display <a>elements</a> fullscreen
@@ -350,6 +375,12 @@ are:
    steps.
   </ol>
 
+ <li>
+  If, {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}'s value is not supported,
+  reject <var>promise</var> with a {{NotSupportedError}} exception and terminate these
+  steps.
+ </li>
+
  <li><p>Let <var>fullscreenElements</var> be an <a>ordered set</a> initially consisting of
  <a>this</a>.
 
@@ -388,6 +419,16 @@ are:
    <li><p><a for=set>Append</a> ({{fullscreenchange}}, <var>element</var>) to
    <var>doc</var>'s <a>list of pending fullscreen events</a>.
   </ol>
+
+  <li>
+  Depending on the value of {{FullscreenOptions}}'s {{FullscreenOptions/keyboardLock}}:
+  <dl switch>
+    <dt>"{{FullscreenKeyboardLock/application}}"</dt>
+    <dd><p>Apply an [=application-level keyboard lock=].
+    <dt>"{{FullscreenKeyboardLock/system}}"</dt>
+    <dd><p>Apply a [=system-level keyboard lock=].
+  </dl>
+ </li>
 
   <p class=note>The order in which elements are <a lt="fullscreen an element">fullscreened</a>
   is not observable, because <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
@@ -506,6 +547,8 @@ could be an open <{dialog}> element.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
+ <li><p>Run [=the release the keyboard lock steps=] with <var>doc</var>.
+
  <li><p>Run the [=fully unlock the screen orientation steps=] with <var>doc</var>.
 
  <li><p>If <var>resize</var> is true, resize <var>doc</var>'s viewport to its "normal" dimensions.
@@ -595,6 +638,11 @@ algorithm as part of the <a>close request steps</a>. This takes precedence over 
 <p>The user agent may end any fullscreen session without a <a>close request</a> or call to
 {{Document/exitFullscreen()}} whenever the user agent deems it necessary.
 
+<p>Users should be clearly notified when [=keyboard locking=] is active, possibly through browser
+UI indicators.
+
+<p>There should be a simple and intuitive method for users to override keyboard locking, reverting
+control back to the system or user agent.
 
 
 <h2 id=rendering>Rendering</h2>
@@ -652,6 +700,30 @@ iframe:fullscreen {
 
 
 
+<h2>keyboard lock</h2>
+
+<p>keyboard Locking enhances the functionality of web applications running in fullscreen by allowing
+them to intercept certain key inputs that would typically be handled by either the system or the
+user agent. This is useful in scenarios such as gaming or remote desktop applications, where keys
+like ESC or function keys are integral to the application's functionality.
+
+<p>A <dfn>keyboard lock</dfn> enables web applications to capture and handle key inputs directly,
+bypassing the default behavior typically executed by the user agent (in the case of
+"{{FullscreenKeyboardLock/application}}") or operating system (in the case of
+"{{FullscreenKeyboardLock/system}}"). When the [=keyboard lock flag=] is set for a [=document=], key
+events that would normally trigger user agent or system-level actions are instead redirected to the
+web application in fullscreen.
+
+<dl>
+  <dt><dfn>Application-level keyboard lock</dfn></dt>
+  <dd><p>Captures all keys that the user agent would ordinarily receive, except those reserved for
+  critical system functions or security shortcuts (e.g., Ctrl+Alt+Del).
+  <dt><dfn>System-level keyboard lock</dfn></dt>
+  <dd><p>capture a wider range of keys, including those used for system-level navigation and
+  shortcuts (e.g., Alt+Tab), subject to user consent and user agent implementation.
+</dl>
+
+
 <h2 id=permissions-policy-integration oldids=feature-policy-integration>Permissions Policy
 Integration</h2>
 
@@ -688,6 +760,12 @@ allowed via permissions policy, either through the <{iframe/allowfullscreen}> at
 delivered with the <a>document</a> through which it is nested.
 
 <p>This prevents e.g. content from third parties to go fullscreen without explicit permission.
+
+<p>When applying a [=keyboard lock=], only a limited set of keys, primarily those not involving
+system control or privacy risks (like Alt+Tab, Ctrl+Alt+Del), can be locked via the API.
+
+<p>When applying a [=keyboard lock=], user agents should implement safeguards to prevent abuse of
+this feature, such as allowing users to override the lock.
 
 
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -700,9 +700,9 @@ iframe:fullscreen {
 
 
 
-<h2 id="keyboard-locking">keyboard locking</h2>
+<h2 id="keyboard-locking">Keyboard Locking</h2>
 
-<p>keyboard Locking enhances the functionality of web applications running in fullscreen by allowing
+<p>Keyboard locking enhances the functionality of web applications running in fullscreen by allowing
 them to intercept certain key inputs that would typically be handled by either the system or the
 user agent. This is useful in scenarios such as gaming or remote desktop applications, where keys
 like ESC or function keys are integral to the application's functionality.
@@ -716,12 +716,17 @@ web application in fullscreen.
 
 <dl>
   <dt><dfn>Application-level keyboard lock</dfn></dt>
-  <dd><p>Captures all keys that the user agent would ordinarily receive, except those reserved for
-  critical system functions or security shortcuts (e.g., Ctrl+Alt+Del).
+  <dd><p>Captures all keys that the user agent would ordinarily receive, such as those that open or
+  close windows. This excludes those reserved for system-level interactions, such
+  as key presses that open system menus or switch applications.
   <dt><dfn>System-level keyboard lock</dfn></dt>
   <dd><p>Capture a wider range of keys, including those used for system-level navigation and
   shortcuts (e.g., Alt+Tab), subject to user consent and user agent implementation.
 </dl>
+
+<p>User agents should reserve an additional input for the purposes of exiting fullscreen.
+There are also some system-level key sequences or combinations that cannot be
+intercepted for security reasons, such as Ctrl+Alt+Del on Windows.
 
 <div algorithm>
   <p>To <dfn>run the release the keyboard lock steps</dfn> for a <a>document</a>
@@ -729,7 +734,8 @@ web application in fullscreen.
   <ol>
     <li><p>If the [=keyboard lock flag=] for the <var>document</var> is not set, abort these steps.
     <li><p>Deactivate the keyboard lock and restore the handling of keyboard inputs to the default
-    behavior of the user agent and the operating system. <li><p>Set the [=keyboard lock flag=] for
+    behavior of the user agent and the operating system.
+    <li><p>Set the [=keyboard lock flag=] for
     the <var>document</var> to <code>false</code>.
   </ol>
 </div>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -241,14 +241,12 @@ partial interface mixin DocumentOrShadowRoot {
   free to honor user preference over the application's. The default value
   "{{FullscreenNavigationUI/auto}}" indicates no application preference.
 
- <dd>
   When supplied, <var>options</var>'s {{FullscreenOptions/keyboardLock}} member indicates whether
-  the supplied keyboard lock mode should apply.
+  the supplied keyboard lock mode will apply.
 
-  If set to "{{FullscreenKeyboardLock/browser}}", [=application-level keyboard lock=] should
-  be applied.
+  If set to "{{FullscreenKeyboardLock/browser}}", [=application-level keyboard lock=] can be applied.
 
-  If set to "{{FullscreenKeyboardLock/system}}", [=system-level keyboard lock=] should be applied.
+  If set to "{{FullscreenKeyboardLock/system}}", [=system-level keyboard lock=] can be applied.
 
   User agents are always free to honor user preference over the application's. The default value
   "{{FullscreenKeyboardLock/none}}" indicates no keyboard lock is applied.


### PR DESCRIPTION
Introduce a dictionary member `keyboardLock` to `requestFullscreen(options)` to request keyboard lock together with fullscreen.

Fixes #231 
<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * [WebKit](https://github.com/WebKit/WebKit/commit/ceba7343025b0e47c2903877198c8bdd5aeda851)
   * Gecko
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/fullscreen/api?label=master&label=experimental&aligned&q=keyboard-lock <!-- If these tests are tentative, link a PR to make them non-tentative. -->
   * https://github.com/web-platform-tests/wpt/pull/59726
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://issues.chromium.org/issues/505427218
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=700123
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=313121
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: https://github.com/mdn/content/issues/43868
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 8, 2026, 9:36 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fwhatwg%2Ffullscreen%2F252503e2787154decf9cdd9945cf07ebcc2c23f0%2Ffullscreen.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20232)

**Error output:**

```json
[
    {
        "lineNum": "114:35",
        "messageType": "link",
        "text": "Multiple possible 'removing steps' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-node-remove-ext\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:removing steps\nspec:geolocation-element; type:dfn; for:ActivationBlockersMixin; text:removing steps\nspec:geolocation-element; type:dfn; for:HTMLGeolocationElement; text:removing steps\nspec:geolocation-element; type:dfn; for:PowerfulFeatureObserver; text:removing steps\n<a bs-line-number=\"114:35\" data-link-type=\"dfn\" data-lt=\"removing steps\">removing steps</a>"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/fullscreen%23232.)._

</details>
