### PR TITLE
WIP: Enable configuration for fullscreen without transient activation

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -278,8 +278,9 @@ are:
 
    <li><p><a>Fullscreen is supported</a>.
 
-   <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a> or the
-   algorithm is <a>triggered by a user generated orientation change</a>.
+   <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a>, the
+   algorithm is <a>triggered by a user generated orientation change</a>, or the user agent has been
+   configured to permit fullscreen without <a>transient activation</a>.
   </ul>
 
  <li><p>If <var>error</var> is false, then <a>consume user activation</a> given
@@ -708,6 +709,7 @@ Josh Soref,
 Kagami Sascha Rosylight,
 Matt Falkenhagen,
 Mihai Balan,
+Mike Wasserman
 Mounir Lamouri,
 Øyvind Stenhaug,
 Pat Ladd,

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -709,7 +709,7 @@ Josh Soref,
 Kagami Sascha Rosylight,
 Matt Falkenhagen,
 Mihai Balan,
-Mike Wasserman
+Mike Wasserman,
 Mounir Lamouri,
 Øyvind Stenhaug,
 Pat Ladd,


### PR DESCRIPTION
<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

Accommodate user agent configurations that permit fullscreen requests without transient activation.

This is a WIP illustrative PR for #234. See the [Explainer](https://github.com/explainers-by-googlers/html-fullscreen-without-a-gesture) for more detail.

- [ ] At least two implementers are interested (and none opposed):
   * Chromium
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * Test driver support for such user agent configurations is required… <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://crbug.com/1501130
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

<!-- (See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.) -->
