### PR TITLE
Don't close ancestor popovers when fullscreening

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -71,7 +71,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
  <var>element</var>, null, and false.
 
  <li><p>If <var>hideUntil</var> is null, then set <var>hideUntil</var> to <var>element</var>'s
- <span>node document</span>.</p></li>
+ <span>node document</span>.
 
  <li><p>Run <a>hide all popovers until</a> given <var>hideUntil</var>, false, and true.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -70,6 +70,9 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
  <li><p>Let <var>hideUntil</var> be the result of running <a>topmost popover ancestor</a> given
  <var>element</var>, null, and false.
 
+ <li><p>If <var>hideUntil</var> is null, then set <var>hideUntil</var> to <var>element</var>'s
+ <span>node document</span>.</p></li>
+
  <li><p>Run <a>hide all popovers until</a> given <var>hideUntil</var>, false, and true.
 
  <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -67,7 +67,10 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 <p>To <dfn>fullscreen an <var>element</var></dfn>:
 
 <ol>
- <li><p>Run <a>hide all popovers</a> given <var>element</var>'s <a>node document</a>.
+ <li><p>Let <var>hideUntil</var> be the result of running <a>topmost popover ancestor</a> given
+ <var>element</var>, null, and false.
+
+ <li><p>Run <a>hide all popovers until</a> given <var>hideUntil</var>, false, and true.
 
  <li><p>Set <var>element</var>'s <a>fullscreen flag</a>.
 


### PR DESCRIPTION
Without this patch, the fullscreening an element inside an open popover will make the fullscreen element display:none.

Issue: https://github.com/whatwg/html/issues/9998
Corresponding HTML PR: https://github.com/whatwg/html/pull/10116

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome
   * https://bugzilla.mozilla.org/show_bug.cgi?id=1888088
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/44146
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1520938
   * Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1888088
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=269928
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: As said in the HTML PR, I'm not sure this edge case warrants any text in MDN
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/237.html" title="Last updated on May 7, 2024, 2:21 AM UTC (4bd1b11)">Preview</a> | <a href="https://whatpr.org/fullscreen/237/4cafed1...4bd1b11.html" title="Last updated on May 7, 2024, 2:21 AM UTC (4bd1b11)">Diff</a>