### PR TITLE
Fix dangling fullscreen flag when exiting a disconnected element

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -495,9 +495,11 @@ could be an open <{dialog}> element.
 
  <li><p>If <var>doc</var>'s <a>fullscreen element</a> is not <a>connected</a>:
   <ol>
-   <li><p><a for=set>Append</a> ({{fullscreenchange}}, <var>doc</var>'s
-   <a>fullscreen element</a>) to <var>doc</var>'s
-   <a>list of pending fullscreen events</a>.
+   <li><p><a for=set>Append</a> ({{fullscreenchange}}, <var>doc</var>'s <a>fullscreen element</a>)
+   to <var>doc</var>'s <a>list of pending fullscreen events</a>.
+
+   <li><p><a lt="unfullscreen an element">Unfullscreen</a> <var>doc</var>'s <a>fullscreen
+   element</a>.
   </ol>
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.


### PR DESCRIPTION
Fixes #217

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Chromium? (seems like shipping behavior)
   * Gecko? (seems like shipping behavior)
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * wpt.fyi/fullscreen/model/move-fullscreen-element.html
   * https://github.com/web-platform-tests/wpt/pull/50625
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: N/A
   * Gecko: N/A
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=253121
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/243.html" title="Last updated on Feb 11, 2025, 12:20 PM UTC (02b02e5)">Preview</a> | <a href="https://whatpr.org/fullscreen/243/3cd33da...02b02e5.html" title="Last updated on Feb 11, 2025, 12:20 PM UTC (02b02e5)">Diff</a>