### PR TITLE
Fix #245 - Addressing new popover values

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -80,7 +80,7 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
  <var>element</var>, <var>document</var>'s <a>showing hint popover list</a>, null, and false.
 
  <li><p>If <var>hideUntil</var> is null, then set <var>hideUntil</var> to the result of running
- topmost popover ancestor, given <var>element</var>, <var>document</var>'s <a>showing auto popover
+ <a>topmost popover ancestor</a>, given <var>element</var>, <var>document</var>'s <a>showing auto popover
  list</a>, null, and false.
 
  <li><p>If <var>hideUntil</var> is null, then set <var>hideUntil</var> to <var>document</var>.

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -11,6 +11,11 @@ Markup Shorthands: css no
 </pre>
 
 <pre class=link-defaults>
+spec:html
+    type:dfn; text:allowed to use
+    type:dfn; text:showing hint popover list
+    type:dfn; text:showing auto popover list
+
 spec:dom
     type:dfn; for:/; text:document
     type:dfn; for:/; text:element
@@ -69,11 +74,16 @@ is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is
 <p>To <dfn>fullscreen an <var>element</var></dfn>:
 
 <ol>
- <li><p>Let <var>hideUntil</var> be the result of running <a>topmost popover ancestor</a> given
- <var>element</var>, null, and false.
+ <li><p>Let <var>document</var> be <var>element</var>'s <a>node document</a>.
 
- <li><p>If <var>hideUntil</var> is null, then set <var>hideUntil</var> to <var>element</var>'s
- <span>node document</span>.
+ <li><p>Let <var>hideUntil</var> be the result of running <a>topmost popover ancestor</a> given
+ <var>element</var>, <var>document</var>'s <a>showing hint popover list</a>, null, and false.
+
+ <li><p>If <var>hideUntil</var> is null, then set <var>hideUntil</var> to the result of running
+ topmost popover ancestor, given <var>element</var>, <var>document</var>'s <a>showing auto popover
+ list</a>, null, and false.
+
+ <li><p>If <var>hideUntil</var> is null, then set <var>hideUntil</var> to <var>document</var>.
 
  <li><p>Run <a>hide all popovers until</a> given <var>hideUntil</var>, false, and true.
 
@@ -725,6 +735,7 @@ Rafał Chłodnicki,
 Riff Jiang,
 Rune Lillesveen,
 Sigbjørn Vik,
+Simon Farre,
 Simon Pieters,
 Tab Atkins-Bittner,
 Takayoshi Kochi,


### PR DESCRIPTION
Since the popover attribute got a new value, it's
"find topmost popover ancestor" algorithm changed, and this PR attempts to address this in the Fullscreen API specification.

After discussing with @lukewarlow  we came to the conclusion that this is probably the intended change for the Fullscreen API spec.

This addresses #245 

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chromium (already implemented like this)
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/247.html" title="Last updated on Dec 18, 2025, 6:26 PM UTC (16a6593)">Preview</a> | <a href="https://whatpr.org/fullscreen/247/1c324ee...16a6593.html" title="Last updated on Dec 18, 2025, 6:26 PM UTC (16a6593)">Diff</a>