### PR TITLE
Add pending fullscreen request flag and promise to document state

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -272,7 +272,7 @@ are:
 <ol>
  <li><p>Let <var>pendingDoc</var> be <a>this</a>'s <a>node document</a>.
 
- <li><p>Let <var>promise</var> be a new promise.
+ <li><p>Let <var>promise</var> be a new {{Promise}}.
 
  <li><p>Set <var>pendingDoc</var>'s [=Document/pending fullscreen request promise=] to <var>promise</var>.
 

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -68,6 +68,14 @@ stated otherwise it is unset.
 <p>All <a for=/>documents</a> have an associated <dfn>list of pending fullscreen events</dfn>, which
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
+<p>All <a for=/>documents</a> have an associated <dfn export>pending fullscreen request flag</dfn>.
+Unless stated otherwise it is unset. When set, it indicates that the document has an outstanding
+fullscreen request that has not yet resolved or been rejected.
+
+<p>All <a for=/>documents</a> have an associated <dfn export>pending fullscreen request promise</dfn>.
+Unless stated otherwise it is null. When not null, it is the promise representing the current pending
+fullscreen request.
+
 <p>To <dfn>fullscreen an <var>element</var></dfn>:
 
 <ol>
@@ -267,6 +275,8 @@ are:
 
  <li><p>Let <var>promise</var> be a new promise.
 
+ <li><p>Set <var>pendingDoc</var>'s <a>pending fullscreen request promise</a> to <var>promise</var>.
+
  <li><p>If <var>pendingDoc</var> is not <a>fully active</a>, then reject <var>promise</var> with a
  {{TypeError}} exception and return <var>promise</var>.
 
@@ -294,6 +304,8 @@ are:
 
  <li><p>If <var>error</var> is false, then <a>consume user activation</a> given
  <var>pendingDoc</var>'s <a>relevant global object</a>.
+
+ <li><p>If <var>error</var> is false, set <var>pendingDoc</var>'s <a>pending fullscreen request</a> flag.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
@@ -343,6 +355,10 @@ are:
   <p>If <var>error</var> is true:
 
   <ol>
+   <li><p>Unset <var>pendingDoc</var>'s <a>pending fullscreen request</a> flag.
+
+   <li><p>Set <var>pendingDoc</var>'s <a>pending fullscreen request promise</a> to null.
+
    <li><p><a for=set>Append</a> ({{fullscreenerror}}, <a>this</a>) to
    <var>pendingDoc</var>'s <a>list of pending fullscreen events</a>.
 
@@ -391,6 +407,10 @@ are:
 
   <p class=note>The order in which elements are <a lt="fullscreen an element">fullscreened</a>
   is not observable, because <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
+
+ <li><p>Unset <var>pendingDoc</var>'s <a>pending fullscreen request</a> flag.
+
+ <li><p>Set <var>pendingDoc</var>'s <a>pending fullscreen request promise</a> to null.
 
  <li><p>Resolve <var>promise</var> with undefined.
 </ol>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -68,12 +68,11 @@ stated otherwise it is unset.
 <p>All <a for=/>documents</a> have an associated <dfn>list of pending fullscreen events</dfn>, which
 is an <a>ordered set</a> of (<a>string</a>, <a>element</a>) <a>tuples</a>. It is initially empty.
 
-<p>All <a for=/>documents</a> have an associated <dfn export>pending fullscreen request flag</dfn>.
-Unless stated otherwise it is unset. When set, it indicates that the document has an outstanding
-fullscreen request that has not yet resolved or been rejected.
+<p>All <a for=/>documents</a> have a <dfn for=Document lt="has pending fullscreen request|pending fullscreen request" export>
+pending fullscreen request</dfn>, which is a boolean. It is initially false.
 
-<p>All <a for=/>documents</a> have an associated <dfn export>pending fullscreen request promise</dfn>.
-Unless stated otherwise it is null. When not null, it is the promise representing the current pending
+<p>All <a for=/>documents</a> have an associated <dfn for=Document export>pending fullscreen request promise</dfn>, 
+which is a nullable {{Promise}}. It is initially null. It represents the current pending
 fullscreen request.
 
 <p>To <dfn>fullscreen an <var>element</var></dfn>:
@@ -275,10 +274,11 @@ are:
 
  <li><p>Let <var>promise</var> be a new promise.
 
- <li><p>Set <var>pendingDoc</var>'s <a>pending fullscreen request promise</a> to <var>promise</var>.
+ <li><p>Set <var>pendingDoc</var>'s [=Document/pending fullscreen request promise=] to <var>promise</var>.
 
- <li><p>If <var>pendingDoc</var> is not <a>fully active</a>, then reject <var>promise</var> with a
- {{TypeError}} exception and return <var>promise</var>.
+ <li><p>If <var>pendingDoc</var> is not <a>fully active</a>, then set <var>pendingDoc</var>'s
+ [=Document/pending fullscreen request promise=] to null, reject <var>promise</var> with a
+ {{TypeError}} exception, and return <var>promise</var>.
 
  <li><p>Let <var>error</var> be false.
 
@@ -305,7 +305,7 @@ are:
  <li><p>If <var>error</var> is false, then <a>consume user activation</a> given
  <var>pendingDoc</var>'s <a>relevant global object</a>.
 
- <li><p>If <var>error</var> is false, set <var>pendingDoc</var>'s <a>pending fullscreen request</a> flag.
+ <li><p>If <var>error</var> is false, then set <var>pendingDoc</var>'s [=Document/pending fullscreen request=] to true.
 
  <li><p>Return <var>promise</var>, and run the remaining steps <a>in parallel</a>.
 
@@ -355,9 +355,9 @@ are:
   <p>If <var>error</var> is true:
 
   <ol>
-   <li><p>Unset <var>pendingDoc</var>'s <a>pending fullscreen request</a> flag.
+   <li><p>Set <var>pendingDoc</var>'s [=Document/pending fullscreen request=] to false.
 
-   <li><p>Set <var>pendingDoc</var>'s <a>pending fullscreen request promise</a> to null.
+   <li><p>Set <var>pendingDoc</var>'s [=Document/pending fullscreen request promise=] to null.
 
    <li><p><a for=set>Append</a> ({{fullscreenerror}}, <a>this</a>) to
    <var>pendingDoc</var>'s <a>list of pending fullscreen events</a>.
@@ -408,9 +408,9 @@ are:
   <p class=note>The order in which elements are <a lt="fullscreen an element">fullscreened</a>
   is not observable, because <a>run the fullscreen steps</a> is invoked in <a>tree order</a>.
 
- <li><p>Unset <var>pendingDoc</var>'s <a>pending fullscreen request</a> flag.
+ <li><p>Set <var>pendingDoc</var>'s [=Document/pending fullscreen request=] to false.
 
- <li><p>Set <var>pendingDoc</var>'s <a>pending fullscreen request promise</a> to null.
+ <li><p>Set <var>pendingDoc</var>'s [=Document/pending fullscreen request promise=] to null.
 
  <li><p>Resolve <var>promise</var> with undefined.
 </ol>

--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -272,7 +272,8 @@ are:
 <ol>
  <li><p>Let <var>pendingDoc</var> be <a>this</a>'s <a>node document</a>.
 
- <li><p>Let <var>promise</var> be a new {{Promise}}.
+
+ <li><p>Let <var>promise</var> be [=a new promise=] in [=this=]'s [=relevant realm=].
 
  <li><p>Set <var>pendingDoc</var>'s [=Document/pending fullscreen request promise=] to <var>promise</var>.
 


### PR DESCRIPTION
Motivated by https://github.com/w3c/screen-orientation/issues/254 and https://github.com/w3c/screen-orientation/issues/255 and https://github.com/w3c/screen-orientation/pull/269

This commit adds exported definitions for both 'pending fullscreen request flag' and 'pending fullscreen request promise' to document state, enabling other specifications to use modern WebIDL patterns.

Changes:
- Add 'pending fullscreen request flag' to document state (exported)
- Add 'pending fullscreen request promise' to document state (exported)
- Set flag and store promise when requestFullscreen() starts processing
- Clear flag and promise when request resolves (success) or rejects (error)
- Use consistent naming conventions without interface binding

The flag enables detecting pending fullscreen requests, while the promise enables other specifications to use WebIDL 'react' patterns to respond to fullscreen request rejections instead of relying on flag state changes.

This enables other specifications (like Screen Orientation) to detect when a document has a pending fullscreen request and react to promise rejections, allowing modern promise-based integration for web compatibility.

<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: …
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [ ] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/251.html" title="Last updated on Oct 28, 2025, 7:11 AM UTC (ec09747)">Preview</a> | <a href="https://whatpr.org/fullscreen/251/75c0c1d...ec09747.html" title="Last updated on Oct 28, 2025, 7:11 AM UTC (ec09747)">Diff</a>