### PR TITLE
Fix link error

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -19,6 +19,7 @@ spec:dom
 spec:infra
     type:dfn; for:set; text:for each
     type:dfn; text:string
+    type:dfn; text:break
 spec:css-position-4
     type:selector; text: ::backdrop
     type:dfn; text:top layer


### PR DESCRIPTION
Markup fix to remove the linking error. (All instances of "break" are referring to the Infra break, not the CSS break.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/fullscreen/252.html" title="Last updated on Dec 2, 2025, 9:29 PM UTC (5144514)">Preview</a> | <a href="https://whatpr.org/fullscreen/252/75c0c1d...5144514.html" title="Last updated on Dec 2, 2025, 9:29 PM UTC (5144514)">Diff</a>