### PR TITLE
Review Draft Publication: January 2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 2
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.14"
     - run: pip install bikeshed && bikeshed update
     # Note: `make deploy` will do a deploy dry run on PRs.
     - run: make deploy

--- a/review-drafts/2026-01.bs
+++ b/review-drafts/2026-01.bs
@@ -1,5 +1,7 @@
 <pre class=metadata>
 Group: WHATWG
+Status: RD
+Date: 2026-01-20
 H1: Fullscreen API
 Shortname: fullscreen
 Text Macro: TWITTER fullscreenapi


### PR DESCRIPTION
The [January 2026 Review Draft](https://fullscreen.spec.whatwg.org/review-drafts/2026-01/) for this Workstream will be published shortly after merging this pull request.

Under the [WHATWG IPR Policy](https://whatwg.org/ipr-policy), Participants may, within 45 days after publication of a Review Draft, exclude certain Essential Patent Claims from the Review Draft Licensing Obligations. See the [IPR Policy](https://whatwg.org/ipr-policy) for details.