### PR TITLE
Bikeshed has migrated to new URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ SHELL=/bin/bash -o pipefail
 .PHONY: local remote deploy
 
 remote: fullscreen.bs
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output fullscreen.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
+						   -F type=bikeshed-spec \
 	                       -F die-on=warning \
 	                       -F md-Text-Macro="COMMIT-SHA LOCAL COPY" \
 	                       -F file=@fullscreen.bs) && \


### PR DESCRIPTION
And beyond that, we also now have to provide the -F type=bikeshed-spec arguments

See https://github.com/w3c/spec-generator/wiki/Migrating-Bikeshed-HTTP-API-usage-to-spec%E2%80%90generator