### PR TITLE
Upstream Document PiP changes to "fullscreen is supported"

### DIFF
--- a/fullscreen.bs
+++ b/fullscreen.bs
@@ -146,8 +146,16 @@ these steps:
 
 <hr>
 
-<p><dfn>Fullscreen is supported</dfn> if there is no previously-established user preference,
-security risk, or platform limitation.
+<p><dfn>Fullscreen is supported</dfn> for a {{Window}} <var>window</var>
+returns true if all of the following are true, and false otherwise:
+
+<ul>
+  <li><p>There is no previously-established user preference, security risk, or platform
+  limitation.
+
+  <li><p><var>window</var>'s <a for="Window">navigable</a>'s <a for="navigable">
+  top-level traversable</a>'s <a>Is Document Picture-in-Picture</a> is false.
+</ul>
 
 <hr>
 
@@ -230,7 +238,7 @@ partial interface mixin DocumentOrShadowRoot {
 
  <dt><code><var>document</var> . {{Document/fullscreenEnabled}}</code>
  <dd><p>Returns true if <var>document</var> has the ability to display <a>elements</a> fullscreen
- and <a>fullscreen is supported</a>, or false otherwise.
+ and <a>fullscreen is supported</a> for its associated {{Window}}, or false otherwise.
 
  <dt><code><var>promise</var> = <var>document</var> . {{Document/exitFullscreen()}}</code>
  <dd><p>Stops <var>document</var>'s <a>fullscreen element</a> from being displayed fullscreen and
@@ -286,7 +294,7 @@ are:
 
    <li><p>The <a>fullscreen element ready check</a> for <a>this</a> returns true.
 
-   <li><p><a>Fullscreen is supported</a>.
+   <li><p><a>Fullscreen is supported</a> for <var>pendingDoc</var>'s <a>relevant global object</a>.
 
    <li><p><a>This</a>'s <a>relevant global object</a> has <a>transient activation</a> or the
    algorithm is <a>triggered by a user generated orientation change</a>.
@@ -401,8 +409,8 @@ to the reader. Input welcome on potential improvements.
 
 <p>The <dfn attribute for=Document><code>fullscreenEnabled</code></dfn> getter steps are to return
 true if <a>this</a> is <a for=/>allowed to use</a> the "<code><a
-data-lt="fullscreen-feature">fullscreen</a></code>" feature and <a>fullscreen is supported</a>, and
-false otherwise.
+data-lt="fullscreen-feature">fullscreen</a></code>" feature and <a>fullscreen is supported</a> for
+<a>this</a>'s <a>relevant global object</a>, and false otherwise.
 
 <p>The <dfn attribute for=Document><code>fullscreen</code></dfn> getter steps are to return false if
 <a>this</a>'s <a>fullscreen element</a> is null, and true otherwise.
@@ -732,6 +740,7 @@ Tab Atkins-Bittner,
 Takayoshi Kochi,
 Theresa O'Connor,
 triple-underscore,
+Vincent Hilla,
 Vincent Scheib, and
 Xidorn Quan
 for also being awesome.


### PR DESCRIPTION
<!--
Thank you for contributing to the Fullscreen API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

I think it makes sense to merge this after https://github.com/whatwg/html/pull/12397 because `Is Document Picture-in-Picture` is currently not exported.

- [ ] At least two implementers are interested (and none opposed):
   * Gecko
   * ...
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://wpt.fyi/results/document-picture-in-picture/pip-fullscreen.https.html
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: already shipped
   * Gecko: already shipped
   * WebKit: open standard position https://github.com/WebKit/standards-positions/issues/41
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: ...
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use.

Fixes https://github.com/whatwg/fullscreen/issues/258


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 22, 2026, 12:05 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fvinhill%2Ffullscreen%2Fe18ca6d324d3e6ba6d3d0365313e99efc8a3b66c%2Ffullscreen.bs&force=1&md-status=LS-PR&md-Text-Macro=PR-NUMBER%20259)

**Error output:**

```json
[
    {
        "lineNum": "114:35",
        "messageType": "link",
        "text": "Multiple possible 'removing steps' dfn refs.\nArbitrarily chose https://dom.spec.whatwg.org/#concept-node-remove-ext\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:dom; type:dfn; text:removing steps\nspec:geolocation-element; type:dfn; for:ActivationBlockersMixin; text:removing steps\nspec:geolocation-element; type:dfn; for:HTMLGeolocationElement; text:removing steps\nspec:geolocation-element; type:dfn; for:PowerfulFeatureObserver; text:removing steps\n<a bs-line-number=\"114:35\" data-link-type=\"dfn\" data-lt=\"removing steps\">removing steps</a>"
    },
    {
        "lineNum": "157:31",
        "messageType": "link",
        "text": "No 'dfn' refs found for 'is document picture-in-picture' that are marked for export.\n  (Possible specs this could be from: document-picture-in-picture)\n<a bs-line-number=\"157:31\" data-link-type=\"dfn\" data-lt=\"Is Document Picture-in-Picture\">Is Document Picture-in-Picture</a>"
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20whatwg/fullscreen%23259.)._

</details>
